### PR TITLE
Add support for custom popup on BondsTable

### DIFF
--- a/src/structbond/basics.jl
+++ b/src/structbond/basics.jl
@@ -5,7 +5,8 @@ using HypertextLiteral
 import PlutoUI.Experimental: wrapped
 using PlutoUI: combine
 
-CSS_Sheets = map(readdir(joinpath(@__DIR__, "css"))) do file
+# Extract CSS that will be used in internal functions
+const CSS_PARTS = map(readdir(joinpath(@__DIR__, "css"))) do file
 	name = replace(file, r"\.[\w]+$" => "") |> Symbol
 	path = joinpath(@__DIR__, "css", file)
 	name => read(path, String)
@@ -107,24 +108,7 @@ function fieldhtml(s::Type, f::Symbol)
 			<field-bond class='$f'>$(Child(fieldbond(s, f)))</field-bond>
 		</field-html>
 		<style>
-			field-html {
-				display: grid;
-				grid-template-columns: 1fr minmax(min(50px, 100%), .4fr);
-				grid-auto-rows: fit-content(40px);
-				justify-items: center;
-				//padding: 2px 5px 10px 0px;
-				align-items: center;
-				row-gap: 5px;
-			}
-			field-bond {
-				display: flex;
-			}
-			field-bond input {
-				width: 100%;
-			}
-   			field-description {
-				text-align: center;
-			}
+		$(CSS_PARTS.fieldhtml)
 		</style>
 		""")
 	end
@@ -162,55 +146,7 @@ function typehtml(T::Type)
 		
 	</script>
 		<style>
-			togglereactive-container field-html {
-				display: contents;
-			}
-			togglereactive-container {
-				display: grid;
-				grid-template-columns: 1fr minmax(min(50px, 100%), .4fr);
-				grid-auto-rows: fit-content(40px);
-				justify-items: center;
-				align-items: center;
-				row-gap: 5px;
-				/* The flex below is needed in some weird cases where the bond is display flex and the child becomes small. */
-				flex: 1;
-			}
-			togglereactive-header {
-				grid-column: 1 / -1;
-				display: flex;
-			}
-			togglereactive-header > .collapse {
-				--size: 17px;
-			    display: block;
-			    align-self: stretch;
-			    background-size: var(--size) var(--size);
-			    background-repeat: no-repeat;
-			    background-position: center;
-			    width: var(--size);
-			    filter: var(--image-filters);
-				background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/chevron-down.svg);
-				cursor: pointer;
-			}
-			togglereactive-container.collapsed > togglereactive-header > .collapse {
-				background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/chevron-forward.svg);
-			}
-			togglereactive-header {
-				display: flex;
-				align-items: stretch;
-				width: 100%;
-			}
-			togglereactive-header > .description {
-				text-align: center;
-				flex-grow: 1;
-				font-size: 18px;
-				font-weight: 600;
-			}
-			togglereactive-header > .toggle {
-				align-self: center
-			}
-			togglereactive-container.collapsed togglereactive-header + * {
-				display: none !important;
-			}
+		$(CSS_PARTS.typehtml)
 		</style>
 		""")
 	end; description = typedescription(T))

--- a/src/structbond/basics.jl
+++ b/src/structbond/basics.jl
@@ -115,7 +115,7 @@ function fieldhtml(s::Type, f::Symbol)
 	return out
 end
 
-function typehtml(T::Type)
+function typehtml(T::Type; description = typedescription(T))
 	inner_bond = combine() do Child
 		@htl """
 		$([
@@ -149,7 +149,7 @@ function typehtml(T::Type)
 		$(CSS_PARTS.typehtml)
 		</style>
 		""")
-	end; description = typedescription(T))
+	end; description)
 end
 
 ### Constructor ###

--- a/src/structbond/css/fieldhtml.css
+++ b/src/structbond/css/fieldhtml.css
@@ -1,0 +1,18 @@
+field-html {
+  display: grid;
+  grid-template-columns: 1fr minmax(min(50px, 100%), 0.4fr);
+  grid-auto-rows: fit-content(40px);
+  justify-items: center;
+  //padding: 2px 5px 10px 0px;
+  align-items: center;
+  row-gap: 5px;
+}
+field-bond {
+  display: flex;
+}
+field-bond input {
+  width: 100%;
+}
+field-description {
+  text-align: center;
+}

--- a/src/structbond/css/typehtml.css
+++ b/src/structbond/css/typehtml.css
@@ -1,0 +1,49 @@
+togglereactive-container field-html {
+  display: contents;
+}
+togglereactive-container {
+  display: grid;
+  grid-template-columns: 1fr minmax(min(50px, 100%), 0.4fr);
+  grid-auto-rows: fit-content(40px);
+  justify-items: center;
+  align-items: center;
+  row-gap: 5px;
+  /* The flex below is needed in some weird cases where the bond is display flex and the child becomes small. */
+  flex: 1;
+}
+togglereactive-header {
+  grid-column: 1 / -1;
+  display: flex;
+}
+togglereactive-header > .collapse {
+  --size: 17px;
+  display: block;
+  align-self: stretch;
+  background-size: var(--size) var(--size);
+  background-repeat: no-repeat;
+  background-position: center;
+  width: var(--size);
+  filter: var(--image-filters);
+  background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/chevron-down.svg);
+  cursor: pointer;
+}
+togglereactive-container.collapsed > togglereactive-header > .collapse {
+  background-image: url(https://cdn.jsdelivr.net/gh/ionic-team/ionicons@5.5.1/src/svg/chevron-forward.svg);
+}
+togglereactive-header {
+  display: flex;
+  align-items: stretch;
+  width: 100%;
+}
+togglereactive-header > .description {
+  text-align: center;
+  flex-grow: 1;
+  font-size: 18px;
+  font-weight: 600;
+}
+togglereactive-header > .toggle {
+  align-self: center;
+}
+togglereactive-container.collapsed togglereactive-header + * {
+  display: none !important;
+}

--- a/src/structbond/main_definitions.jl
+++ b/src/structbond/main_definitions.jl
@@ -31,7 +31,7 @@ Base.@kwdef struct StructBond{T}
 	description::Any
 	secret_key::String=String(rand('a':'z', 10))
 end
-StructBond(::Type{T}; description = typedescription(T)) where T = StructBond{T}(;widget = typehtml(T), description)
+StructBond(::Type{T}; description = typedescription(T)) where T = StructBond{T}(;widget = typehtml(T; description), description)
 
 ## structbondtype ##
 structbondtype(::StructBond{T}) where T = T
@@ -78,11 +78,7 @@ _show(t::StructBond{T}) where T = @htl("""
 	<script id = $(t.secret_key)>
 		
 		const parent = currentScript.parentElement
-		const widget = currentScript.previousElementSibling
-	
-		// Overwrite the description
-		const desc = widget.querySelector('.description')
-		desc.innerHTML = $(t.description)
+		const widget = parent.firstElementChild
 	
 		// Set-Get bond
 	

--- a/src/structbond/main_definitions.jl
+++ b/src/structbond/main_definitions.jl
@@ -155,7 +155,7 @@ Base.show(io::IO, mime::MIME"text/html", bd::BondWithDescription) = show(io, mim
 		$(bd.bond)
 	</bond-value>
 	<style>
-		$(CSS_Sheets.bondwithdescription)
+		$(CSS_PARTS.bondwithdescription)
 	</style>
 </bond-with-description>
 """))
@@ -188,7 +188,7 @@ Base.show(io::IO, mime::MIME"text/html", bl::BondsList) = show(io, mime, @htl(""
 		collapse_btn.onclick = (e) => container.collapse()
 	</script>
 	<style>
-	$(CSS_Sheets.bondslist)		
+	$(CSS_PARTS.bondslist)		
 	</style>
 </bondslist-container>
 """))
@@ -364,7 +364,7 @@ _show_popout(p::Popout) = wrapped() do Child
 	header.onmouseleave = (e) => container.classList.toggle('header-hover', false)
 </script>
 <style>
-	$(CSS_Sheets.popout)
+	$(CSS_PARTS.popout)
 </style>
 """)
 end
@@ -455,7 +455,7 @@ bondtable_interaction_handler = HTLScriptPart(@htl """
 ## CSS - BondTable ##
 bondtable_style = @htl """
 <style>
-	$(CSS_Sheets.bondtable)
+	$(CSS_PARTS.bondtable)
 </style>
 """;
 

--- a/src/structbond/test_structbondmodule.jl
+++ b/src/structbond/test_structbondmodule.jl
@@ -69,7 +69,7 @@ end
 	d = TextField() # No description, defaults to the docstring since it's present
 	e = Slider(20:25) # No description, defaults to the fieldname as no docstring is present
 end
-asd_bond = @bind asd StructBond(ASD; description = "Custom Description")
+asd_bond = @bind asd StructBond(ASD; description = md"*LOL*")
 end
 
 # ╔═╡ cdc0a7ad-a3ac-4270-b707-35b1939da276
@@ -366,26 +366,26 @@ version = "17.4.0+0"
 # ╠═8db82e94-5c81-4c52-9228-7e22395fb68f
 # ╠═949ac1ef-c502-4e28-81ff-f99b0d19aa03
 # ╠═707175a9-d356-43cf-8038-620ebc401c93
-# ╠═4843983c-df64-4b94-8634-7a10d9423a70
+# ╟─4843983c-df64-4b94-8634-7a10d9423a70
 # ╟─a8995224-83c6-4f82-b5a5-87a6f86fc7a0
 # ╠═9e3601f5-efc2-44e9-83d8-5b65ce7e9ccf
 # ╠═cdc0a7ad-a3ac-4270-b707-35b1939da276
-# ╠═49516374-f625-4a84-ac5c-f92497d45025
-# ╠═8cc53cd2-9114-4067-ab0b-37fd8cd79240
+# ╟─49516374-f625-4a84-ac5c-f92497d45025
+# ╟─8cc53cd2-9114-4067-ab0b-37fd8cd79240
 # ╠═0db51d39-7c05-4e00-b951-7fe776a8e0f9
 # ╠═e2b79a58-e66e-4d40-8673-418823753b38
-# ╠═9d23382c-cf35-4b20-a46c-0f4e2de17fc7
-# ╠═959acb40-1fd6-43f5-a1a6-73a6ceaae1d7
+# ╟─9d23382c-cf35-4b20-a46c-0f4e2de17fc7
+# ╟─959acb40-1fd6-43f5-a1a6-73a6ceaae1d7
 # ╠═4d611425-c8e3-4bc3-912b-8bc0465363bc
 # ╠═a5490a6b-dc11-42b7-87e0-d38870fc55e4
-# ╠═2ee7f26d-f383-4e7e-a69a-8fb72717467c
-# ╠═79beba88-932f-4147-b3a0-d821ef1bc1e2
+# ╟─2ee7f26d-f383-4e7e-a69a-8fb72717467c
+# ╟─79beba88-932f-4147-b3a0-d821ef1bc1e2
 # ╠═63d6c2df-a411-407c-af11-4f5d09fbb322
 # ╠═633029af-8cac-426e-b35c-c9fb3938b784
-# ╠═2073f11e-8196-4ebc-922f-5fa589e91797
-# ╠═811cf78b-e870-45bb-9173-89a3b3d495f5
-# ╠═3a066bf4-3466-469e-90d0-6b14be3ed8d5
-# ╠═3213d977-7b65-43b0-a881-10fcc2523f14
+# ╟─2073f11e-8196-4ebc-922f-5fa589e91797
+# ╟─811cf78b-e870-45bb-9173-89a3b3d495f5
+# ╟─3a066bf4-3466-469e-90d0-6b14be3ed8d5
+# ╟─3213d977-7b65-43b0-a881-10fcc2523f14
 # ╠═903fee67-6b23-41dc-a03d-f1040b696be6
 # ╟─00000000-0000-0000-0000-000000000001
 # ╟─00000000-0000-0000-0000-000000000002

--- a/src/toggle_reactive_bond.jl
+++ b/src/toggle_reactive_bond.jl
@@ -33,7 +33,7 @@ md"""
 begin
 	Base.@kwdef struct ToggleReactiveBond
 		element::Any
-		description::String
+		description::Any
 		secret_key::String=String(rand('a':'z', 10))
 	end
 	ToggleReactiveBond(element; description = "") = ToggleReactiveBond(;element, description)


### PR DESCRIPTION
This PR adds support for custom popups on BondsTable rows.

It will fix #14