### PR TITLE
collect reinterpreted arrays

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,6 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 PlutoExtras = "ed5d0301-4775-4676-b788-cf71e66ff8ed"
+
+[compat]
+Documenter = "0.27"

--- a/src/structbond/main_definitions.jl
+++ b/src/structbond/main_definitions.jl
@@ -129,8 +129,6 @@ function collect_reinterpret!(x::AbstractArray)
 		elseif el isa AbstractArray
 			# We do recursive processing
 			collect_reinterpret!(el)
-		else
-			# We do nothing
 		end
 	end
 	return x

--- a/test/structbond.jl
+++ b/test/structbond.jl
@@ -4,7 +4,7 @@ load_notebook, Configuration, set_bond_values_reactive
 using PlutoExtras
 using Markdown
 using PlutoExtras.StructBondModule
-using PlutoExtras.StructBondModule: structbondtype, popoutwrap, fieldbond, NotDefined, typeasfield
+using PlutoExtras.StructBondModule: structbondtype, popoutwrap, fieldbond, NotDefined, typeasfield, collect_reinterpret!
 import PlutoExtras.AbstractPlutoDingetjes.Bonds
 using Test
 
@@ -66,6 +66,20 @@ function noerror(cell; verbose=true)
     !cell.errored
 end
 
+@testset "collect_reinterpret!" begin
+    @test collect_reinterpret!(3) === 3   
+    re = collect(reinterpret(UInt8, [.5])) |> x -> reinterpret(Float64, x)
+    arr = [
+        0.2,
+        [1.0],
+        re,
+    ]
+    @test collect_reinterpret!(arr) == [
+        0.2,
+        [1.0],
+        [0.5],
+    ]
+end
 
 options = Configuration.from_flat_kwargs(; disable_writing_notebook_files=true)
 srcdir = normpath(@__DIR__, "./notebooks")


### PR DESCRIPTION
This PR adds a function that parses the returned array from JS and collects all the `reinterpreted` arrays within.

Should fix #31 (Only time or @BlueTeo91 will tell)