### PR TITLE
remove dependency on PlutoDevMacros

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,11 +29,12 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
+          - macOS-latest
         arch:
           - x64
     steps:
       - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
@@ -41,6 +42,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -5,19 +5,21 @@ version = "0.7.12"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"
+DocStringExtensions = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
-PlutoDevMacros = "a0499f29-c39b-4c5c-807c-88074221b949"
 PlutoUI = "7f904dfe-b85e-4ff6-b463-dae2292396a8"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 AbstractPlutoDingetjes = "1"
+DocStringExtensions = "0.9"
 HypertextLiteral = "0.9"
 InteractiveUtils = "1"
 Markdown = "1"
-PlutoDevMacros = "0.6, 0.7"
 PlutoUI = "0.7.51"
 REPL = "1"
+Random = "1"
 julia = "1.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PlutoExtras"
 uuid = "ed5d0301-4775-4676-b788-cf71e66ff8ed"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.7.12"
+version = "0.7.13-DEV"
 
 [deps]
 AbstractPlutoDingetjes = "6e696c72-6542-2067-7265-42206c756150"

--- a/notebooks/test_bondstable.jl
+++ b/notebooks/test_bondstable.jl
@@ -1,5 +1,5 @@
 ### A Pluto.jl notebook ###
-# v0.19.22
+# v0.19.43
 
 #> custom_attrs = ["hide-enabled"]
 

--- a/src/PlutoExtras.jl
+++ b/src/PlutoExtras.jl
@@ -21,6 +21,8 @@ end
 export Editable, StringOnEnter # from basic_widgets.jl
 export ToggleReactiveBond # From within StructBondModule
 
+include("combine_htl/PlutoCombineHTL.jl")
+
 include("basic_widgets.jl")
 include("latex_equations.jl") 
 module ExtendedToc include("extended_toc.jl") end

--- a/src/PlutoExtras.jl
+++ b/src/PlutoExtras.jl
@@ -1,7 +1,5 @@
 module PlutoExtras
 using HypertextLiteral
-using PlutoDevMacros
-using PlutoDevMacros.PlutoCombineHTL.WithTypes
 using AbstractPlutoDingetjes.Bonds
 using AbstractPlutoDingetjes
 import PlutoUI

--- a/src/combine_htl/PlutoCombineHTL.jl
+++ b/src/combine_htl/PlutoCombineHTL.jl
@@ -1,0 +1,52 @@
+module PlutoCombineHTL
+
+using Random
+using HypertextLiteral
+using HypertextLiteral: Result, Bypass, Reprint, Render
+using AbstractPlutoDingetjes: is_inside_pluto, AbstractPlutoDingetjes
+using AbstractPlutoDingetjes.Display
+using DocStringExtensions
+
+export make_node, make_html, make_script, formatted_code
+
+const LOCAL_MODULE_URL = Ref("https://cdn.jsdelivr.net/gh/disberd/PlutoExtras@$(pkgversion(@__MODULE__))/src/combine_htl/pluto_compat.js")
+
+include("typedef.jl")
+include("helpers.jl")
+include("constructors.jl")
+include("js_events.jl")
+# include("combine.jl")
+include("show.jl")
+# include("docstrings.jl")
+
+module WithTypes
+    _ex_names = (
+        :PlutoCombineHTL,
+        :make_node, :make_html, :make_script, 
+        :formatted_code, :print_html, :print_javascript, :to_string,
+        :ScriptContent,
+        :PrintToScript,
+        :Node, :DualNode, :CombinedNodes, :PlutoNode, :NormalNode,
+        :Script, :DualScript, :CombinedScripts, :PlutoScript, :NormalScript,
+        :SingleDisplayLocation, :DisplayLocation, :InsidePluto, :OutsidePluto, :InsideAndOutsidePluto,
+        :ShowWithPrintHTML, :AbstractHTML
+    )
+    for n in _ex_names
+        eval(:(import ..PlutoCombineHTL: $n))
+        eval(:(export $n))
+    end
+end
+
+module HelperFunctions
+    _ex_names = (
+        :shouldskip, :haslisteners, :hasreturn, :returned_element,
+        :script_id, :add_pluto_compat, :hasinvalidation, :plutodefault,
+        :displaylocation, :children, :inner_node,
+    )
+    for n in _ex_names
+        eval(:(import ..PlutoCombineHTL: $n))
+        eval(:(export $n))
+    end
+end
+
+end

--- a/src/combine_htl/PlutoCombineHTL.jl
+++ b/src/combine_htl/PlutoCombineHTL.jl
@@ -6,6 +6,7 @@ using HypertextLiteral: Result, Bypass, Reprint, Render
 using AbstractPlutoDingetjes: is_inside_pluto, AbstractPlutoDingetjes
 using AbstractPlutoDingetjes.Display
 using DocStringExtensions
+using Markdown
 
 export make_node, make_html, make_script, formatted_code
 

--- a/src/combine_htl/constructors.jl
+++ b/src/combine_htl/constructors.jl
@@ -1,0 +1,132 @@
+# Abstract Constructors #
+
+Script(::InsidePluto) = PlutoScript
+Script(::OutsidePluto) = NormalScript
+Script(::InsideAndOutsidePluto) = DualScript
+
+Node(::InsidePluto) = PlutoNode
+Node(::OutsidePluto) = NormalNode
+Node(::InsideAndOutsidePluto) = DualNode
+
+# ScriptContent #
+
+## AbstractString constructor ##
+function ScriptContent(s::AbstractString; kwargs...)
+	# We strip eventual leading newline or trailing `isspace`
+	str = strip_nl(s)
+	ael = get(kwargs, :addedEventListeners) do
+		contains(str, "addScriptEventListeners(")
+	end
+	ScriptContent(str, ael)
+end
+
+## Result constructor ##
+function ScriptContent(r::Result; iocontext = IOContext(devnull), kwargs...)
+	temp = IOContext(IOBuffer(), iocontext)
+	show(temp, r)
+	str_content = strip(String(take!(temp.io)))
+	isempty(str_content) && return ScriptContent()
+	n_matches = 0
+	first_idx = 0
+	first_offset = 0
+	last_idx = 0
+	start_regexp = r"<script[^>]*>"
+	end_regexp = r"</script>"
+	for m in eachmatch(r"<script[^>]*>", str_content)
+		n_matches += 1
+		n_matches > 1 && break
+		first_offset = m.offset
+		first_idx = first_offset + length(m.match)
+		m_end = match(end_regexp, str_content, first_idx)
+		m_end === nothing && error("No closing </script> tag was found in the input")
+		last_idx = m_end.offset - 1
+	end
+	if n_matches === 0
+		@warn "No <script> tag was found. 
+Remember that the `ScriptContent` constructor only extract the content between the first <script> tag it finds when using an input of type `HypertextLiteral.Result`" maxlog = 1
+		return ScriptContent()
+	elseif n_matches > 1
+		@warn "More than one <script> tag was found. 
+Only the contents of the first one have been extracted" maxlog = 1
+	elseif first_offset > 1 || last_idx < length(str_content) - length("</script>")
+		@warn "The provided input also contained contents outside of the <script> tag. 
+This content has been discarded" maxlog = 1 
+	end
+	ScriptContent(str_content[first_idx:last_idx]; kwargs...)
+end
+
+## Other Constructors ##
+ScriptContent(p::ScriptContent; kwargs...) = p
+ScriptContent() = ScriptContent("", false)
+ScriptContent(::Union{Missing, Nothing}; kwargs...) = missing
+
+# PlutoScript #
+PlutoScript(;body = missing, invalidation = missing, id = missing, returned_element = missing, kwargs...) = PlutoScript(body, invalidation, id, returned_element; kwargs...)
+# Custom Constructors
+PlutoScript(body; kwargs...) = PlutoScript(;body, kwargs...)
+PlutoScript(body, invalidation; kwargs...) = PlutoScript(body; invalidation, kwargs...)
+# Identity/Copy with modification
+function PlutoScript(s::PlutoScript; kwargs...) 
+    (;body, invalidation, id, returned_element) = s
+    PlutoScript(;body, invalidation, id, returned_element, kwargs...)
+end
+# From other scripts
+PlutoScript(n::NormalScript; kwargs...) = error("You can't construct a PlutoScript with a NormalScript as input")
+PlutoScript(ds::DualScript; kwargs...) = PlutoScript(inner_node(ds, InsidePluto()); kwargs...)
+
+# NormalScript #
+NormalScript(;body = missing, add_pluto_compat = true, id = missing, returned_element = missing, kwargs...) = NormalScript(body, add_pluto_compat, id, returned_element; kwargs...)
+# Custom constructor
+NormalScript(body; kwargs...) = NormalScript(;body, kwargs...)
+# Identity/Copy with modification
+function NormalScript(s::NormalScript; kwargs...) 
+    (;body, add_pluto_compat, id, returned_element) = s
+    NormalScript(;body, add_pluto_compat, id, returned_element, kwargs...)
+end
+# From other scripts
+NormalScript(ps::PlutoScript; kwargs...) = error("You can't construct a `NormalScript` from a `PlutoScript`")
+NormalScript(ds::DualScript; kwargs...) = NormalScript(inner_node(ds, OutsidePluto()); kwargs...)
+
+# DualScript #
+# Constructor with single non-script body. It mirrors the body both in the Pluto and Normal
+DualScript(body; kwargs...) = DualScript(body, body; kwargs...)
+# From Other Scripts
+DualScript(i::PlutoScript; kwargs...) = DualScript(i, NormalScript(); kwargs...)
+DualScript(o::NormalScript; kwargs...) = DualScript(PlutoScript(), o; kwargs...)
+DualScript(ds::DualScript; kwargs...) = DualScript(ds.inside_pluto, ds.outside_pluto; kwargs...)
+
+# CombinedScripts #
+function CombinedScripts(v::Vector; kwargs...)
+	pts_vec = map(v) do el
+		make_script(el) |> PrintToScript
+	end
+    filtered = filter(pts_vec) do el
+		skip_both = shouldskip(el, InsidePluto()) && shouldskip(el, OutsidePluto())
+		!skip_both
+    end 
+    CombinedScripts(filtered; kwargs...)
+end
+CombinedScripts(cs::CombinedScripts) = cs
+CombinedScripts(el) = CombinedScripts([el])
+
+# CombinedNodes #
+CombinedNodes(cn::CombinedNodes) = cn
+CombinedNodes(el) = CombinedNodes([el])
+
+# ShowWithPrintHTML #
+ShowWithPrintHTML(@nospecialize(t); display_type = displaylocation(t)) = ShowWithPrintHTML(t, displaylocation(display_type))
+ShowWithPrintHTML(@nospecialize(t::ShowWithPrintHTML); display_type = displaylocation(t)) = ShowWithPrintHTML(t.el, displaylocation(display_type))
+ShowWithPrintHTML(@nospecialize(t::PrintToScript); kwargs...) = error("You can't wrap object of type $(typeof(t)) with ShowWithPrintHTML")
+
+# PrintToScript #
+PrintToScript(@nospecialize(t); display_type = displaylocation(t)) = PrintToScript(t, displaylocation(display_type))
+PrintToScript(@nospecialize(t::PrintToScript); display_type = displaylocation(t)) = PrintToScript(t.el, displaylocation(display_type))
+PrintToScript(@nospecialize(t::AbstractHTML); kwargs...) = error("You can't wrap object of type $(typeof(t)) with PrintToScript")
+PrintToScript(@nospecialize(t::Union{SingleScript, DualScript}); display_type = displaylocation(t)) = PrintToScript(t, displaylocation(display_type))
+PrintToScript(x::Union{AbstractString, ScriptContent, Result}; kwargs...) = PrintToScript(DualScript(ScriptContent(x)); kwargs...)
+
+# DualNode #
+DualNode(i, o) = DualNode(PlutoNode(i), NormalNode(o))
+DualNode(i::PlutoNode) = DualNode(i, NormalNode())
+DualNode(o::NormalNode) = DualNode(PlutoNode(), o)
+DualNode(dn::DualNode) = dn

--- a/src/combine_htl/helpers.jl
+++ b/src/combine_htl/helpers.jl
@@ -1,0 +1,180 @@
+# Basics
+plutodefault(::Union{InsidePluto, InsideAndOutsidePluto}) = true
+plutodefault(::OutsidePluto) = false
+plutodefault(::Type{D}) where D <: DisplayLocation = plutodefault(D())
+plutodefault(@nospecialize(x::Union{AbstractHTML, PrintToScript})) = plutodefault(displaylocation(x))
+# Methods that gets IO as first argument and a ShowWithPrintHTML as second.
+# These are used to select the correct default for ShowWithPrintHTML
+plutodefault(io::IO, @nospecialize(x::ShowWithPrintHTML{InsideAndOutsidePluto})) = is_inside_pluto(io)
+plutodefault(::IO, @nospecialize(x::ShowWithPrintHTML)) = plutodefault(x)
+
+displaylocation(@nospecialize(x)) = InsideAndOutsidePluto()
+displaylocation(d::DisplayLocation) = d
+displaylocation(pluto::Bool) = pluto ? InsidePluto() : OutsidePluto()
+displaylocation(::AbstractHTML{D}) where D <: DisplayLocation = D()
+displaylocation(::PrintToScript{D}) where D <: DisplayLocation = D()
+function displaylocation(s::Symbol)
+    if s in (:Pluto, :pluto, :inside, :Inside)
+        InsidePluto()
+    elseif s in (:Normal, :normal, :outside, :Outside)
+        OutsidePluto()
+    elseif s in (:both, :Both, :insideandoutside, :InsideAndOutside)
+        InsideAndOutsidePluto()
+    else
+        error("The provided symbol can not identify a display location.
+Please use one of the following:
+- :Pluto, :pluto or :inside, :Inside to display inside Pluto
+- :Normal, :normal or :outside, :Outside to display outside Pluto
+- :both, :Both, :InsideAndOutside or :insideandoutside to display both inside and outside Pluto
+    ")
+    end
+end
+
+children(cs::CombinedScripts) = cs.scripts
+children(cn::CombinedNodes) = cn.nodes
+
+_eltype(pts::PrintToScript{<:DisplayLocation, T}) where T = T
+_eltype(swph::ShowWithPrintHTML{<:DisplayLocation, T}) where T = T
+
+# We create some common methods for the functions below
+for F in (:haslisteners, :hasreturn, :returned_element, :script_id)
+    quote
+        $F(l::DisplayLocation; kwargs...) = x -> $F(x, l; kwargs...)
+        $F(ds::DualScript, l::SingleDisplayLocation; kwargs...) = $F(inner_node(ds, l); kwargs...)
+    end |> eval
+end
+
+# shouldskip
+shouldskip(l::SingleDisplayLocation) = x -> shouldskip(x, l)
+shouldskip(source_location::DisplayLocation, display_location::SingleDisplayLocation) = source_location isa InsideAndOutsidePluto ? false : source_location !== display_location
+shouldskip(s::AbstractString, args...) = isempty(s)
+shouldskip(::Missing, args...) = true
+shouldskip(p::ScriptContent, args...) = shouldskip(p.content, args...)
+shouldskip(::Any, args...) = (@nospecialize; return false)
+shouldskip(n::AbstractHTML, l::SingleDisplayLocation) = (@nospecialize; shouldskip(displaylocation(n), l))
+
+shouldskip(x::PlutoScript, ::InsidePluto) = shouldskip(x.body) && shouldskip(x.invalidation) && shouldskip(x.id) && !hasreturn(x)
+shouldskip(x::NormalScript, ::OutsidePluto) = shouldskip(x.body) && shouldskip(x.id) && !hasreturn(x)
+shouldskip(n::NonScript{L}, ::L) where L <: SingleDisplayLocation = n.empty
+# Dual Script/Node
+shouldskip(d::Dual, l::SingleDisplayLocation) = shouldskip(inner_node(d, l), l)
+# Combined
+shouldskip(c::Combined, l::SingleDisplayLocation) = all(shouldskip(l), children(c))
+function shouldskip(wrapper::Union{ShowWithPrintHTML, PrintToScript}, l::SingleDisplayLocation)
+    el = wrapper.el
+    if el isa AbstractHTML
+        shouldskip(el, l)
+    else
+        shouldskip(displaylocation(wrapper), l)
+    end
+end
+# HypertextLiteral methods
+shouldskip(x::Bypass, args...) = shouldskip(x.content)
+shouldskip(x::Render, args...) = shouldskip(x.content)
+
+# add_pluto_compat
+add_pluto_compat(@nospecialize(::Any)) = false
+add_pluto_compat(ns::NormalScript) =  ns.add_pluto_compat
+add_pluto_compat(ds::DualScript) = add_pluto_compat(inner_node(ds, OutsidePluto()))
+add_pluto_compat(v::Vector{<:PrintToScript}) = any(add_pluto_compat, v)
+add_pluto_compat(cs::CombinedScripts) = add_pluto_compat(children(cs))
+add_pluto_compat(pts::PrintToScript) = add_pluto_compat(pts.el)
+
+# hasinvalidation
+hasinvalidation(@nospecialize(::Any)) = false
+hasinvalidation(s::PlutoScript) = !shouldskip(s.invalidation)
+hasinvalidation(ds::DualScript) = hasinvalidation(inner_node(ds, InsidePluto()))
+hasinvalidation(v::Vector{<:PrintToScript}) = any(hasinvalidation, v)
+hasinvalidation(cs::CombinedScripts) = hasinvalidation(children(cs))
+hasinvalidation(ps::PrintToScript) = hasinvalidation(ps.el)
+
+# haslisteners
+haslisteners(::Missing) = false
+haslisteners(s::ScriptContent) = s.addedEventListeners
+haslisteners(s::SingleScript, l::DisplayLocation = displaylocation(s)) = l == displaylocation(s) ? haslisteners(s.body) : false
+haslisteners(cs::CombinedScripts, l::DisplayLocation) = any(haslisteners(l), children(cs))
+haslisteners(::PrintToScript, args...) = (@nospecialize; false)
+haslisteners(pts::PrintToScript{<:DisplayLocation, <:Script}, args...) = (@nospecialize; haslisteners(pts.el, args...))
+
+# hasreturn
+hasreturn(s::SingleScript, l::DisplayLocation = displaylocation(s)) = l == displaylocation(s) ? !ismissing(returned_element(s)) : false
+hasreturn(cs::CombinedScripts, l::DisplayLocation) = any(hasreturn(l), children(cs))
+hasreturn(::PrintToScript, args...) = (@nospecialize; return false)
+hasreturn(pts::PrintToScript{<:DisplayLocation, <:Script}, args...) = (@nospecialize; hasreturn(pts.el, args...))
+    
+# returned_element
+returned_element(s::SingleScript, l::DisplayLocation = displaylocation(s)) = l == displaylocation(s) ? s.returned_element : missing
+# We check for duplicate returns in the constructor so we just get the return from the last script
+function returned_element(cs::CombinedScripts, l::DisplayLocation)
+    @inbounds for pts in children(cs)
+        hasreturn(pts, l) && return returned_element(pts, l)
+    end
+    return missing
+end
+returned_element(pts::PrintToScript{<:DisplayLocation, <:Script}, args...) = (@nospecialize; returned_element(pts.el, args...))
+
+function script_id(s::SingleScript, l = displaylocation(s); default::Union{String, Missing} = randstring(6)) 
+    if l == displaylocation(s) 
+        ismissing(s.id) ? default : s.id
+    else
+        missing 
+    end
+end
+function script_id(cs::CombinedScripts, l::SingleDisplayLocation; default = randstring(6))
+    for pts in children(cs)
+        id = script_id(pts, l; default = missing)
+        id isa String && return id
+    end
+    return default
+end
+script_id(::PrintToScript, args...; kwargs...) = (@nospecialize; return missing)
+script_id(pts::PrintToScript{<:DisplayLocation, <:Script}, args...; kwargs...) = (@nospecialize; script_id(pts.el, args...; kwargs...))
+
+inner_node(ds::Union{DualNode, DualScript}, ::InsidePluto) = ds.inside_pluto
+inner_node(ds::Union{DualNode, DualScript}, ::OutsidePluto) = ds.outside_pluto
+
+## Make Script ##
+"""
+$TYPEDSIGNATURES
+GESU
+"""
+make_script(; type = :both, kwargs...) = make_script(displaylocation(type); kwargs...)
+make_script(type::Symbol, args...; kwargs...) = make_script(displaylocation(type), args...; kwargs...)
+# Basic location-based constructors
+make_script(::InsideAndOutsidePluto; body = missing, invalidation = missing, inside = PlutoScript(body, invalidation), outside = NormalScript(body), kwargs...) = DualScript(inside, outside; kwargs...)
+make_script(l::SingleDisplayLocation; kwargs...) = Script(l)(;kwargs...)
+# Take a Script as Second argument
+make_script(l::DisplayLocation, x::Union{SingleScript, DualScript}; kwargs...) = Script(l)(x; kwargs...)
+# Other with no location
+make_script(body; kwargs...) = make_script(;body, kwargs...)
+make_script(i, o; kwargs...) = DualScript(i, o; kwargs...)
+make_script(x::Script; kwargs...) = make_script(displaylocation(x), x; kwargs...)
+make_script(x::CombinedScripts) = x
+make_script(v::Vector; kwargs...) = CombinedScripts(v; kwargs...)
+# From ShowWithPrintHTML
+make_script(@nospecialize(s::ShowWithPrintHTML{<:DisplayLocation, <:Script})) = s.el
+make_script(@nospecialize(s::ShowWithPrintHTML)) = error("make_script on `ShowWithPrintHTML{T}` types is only valid if `T <: Script`")
+# From PrintToScript, this is just to have a no-op when calling make_script inside CombinedScripts
+make_script(@nospecialize(s::PrintToScript)) = s
+
+## Make Node ##
+# only kwargs method
+make_node(; type = :both, kwargs...) = make_node(displaylocation(type); kwargs...)
+# Symbol + args method
+make_node(type::Symbol, args...; kwargs...) = make_node(displaylocation(type), args...; kwargs...)
+# Methods with location as first argument and kwargs...
+make_node(::InsideAndOutsidePluto; inside = "", outside = "") = DualNode(inside, outside)
+make_node(l::SingleDisplayLocation; content = "") = Node(l)(content)
+# Methods with location as first argument and args
+make_node(::InsideAndOutsidePluto, inside, outside=inside) = DualNode(inside, outside)
+make_node(l::SingleDisplayLocation, content, args...) = Node(l)(content, args...)
+# Defaults without location
+make_node(n::Node) = n
+make_node(i, o) = DualNode(i, o)
+make_node(content) = DualNode(content, content)
+make_node(v::Vector) = CombinedNodes(v)
+make_node(pts::PrintToScript) = CombinedScripts([pts])
+
+## Make HTML ##
+make_html(x; kwargs...) = ShowWithPrintHTML(make_node(x); kwargs...)
+make_html(@nospecialize(x::ShowWithPrintHTML); kwargs...) = ShowWithPrintHTML(x; kwargs...)

--- a/src/combine_htl/js_events.jl
+++ b/src/combine_htl/js_events.jl
@@ -1,0 +1,45 @@
+## Automatic Event Listeners - DualScript ##
+
+_events_listeners_preamble = let
+	body = ScriptContent("""	/* # JS Listeners Preamble added by PlutoExtras */
+	// Array where all the event listeners are stored
+	const _events_listeners_ = []
+
+	// Function that can be called to add events listeners within the script
+	function addScriptEventListeners(element, listeners) {
+		if (listeners.constructor != Object) {
+			error('Only objects with keys as event names and values as listener functions are supported')
+		}
+		_events_listeners_.push({element, listeners})
+	}
+	/* # JS Listeners Preamble added by PlutoExtras */
+""", false) # We for this to avoid detecting the listeners and avoid stripping newlines
+	ds = DualScript(PlutoScript(body), NormalScript(body)) |> PrintToScript
+end
+
+_events_listeners_postamble = let
+	body = ScriptContent("""
+
+	/* # JS Listeners Postamble added by PlutoExtras */
+	// Assign the various events listeners defined within the script
+	for (const item of _events_listeners_) {
+		const { element, listeners } = item
+		for (const [name, func] of _.entries(listeners)) {
+  			element.addEventListener(name, func)
+		}
+	}
+	/* # JS Listeners Postamble added by PlutoExtras */""",
+	false)
+	invalidation = ScriptContent("""
+	/* # JS Listeners invalidation added by PlutoExtras */
+	// Remove the events listeners during invalidation
+	for (const item of _events_listeners_) {
+		const { element, listeners } = item
+		for (const [name, func] of _.entries(listeners)) {
+			element.removeEventListener(name, func)
+		}
+	}
+	/* # JS Listeners invalidation added by PlutoExtras */
+"""; addedEventListeners = false)
+	ds = DualScript(PlutoScript(body, invalidation), NormalScript(body)) |> PrintToScript
+end

--- a/src/combine_htl/pluto_compat.js
+++ b/src/combine_htl/pluto_compat.js
@@ -1,0 +1,27 @@
+/* 
+This simple module simply tries to recreate the same environment created by
+Pluto and is mostly based on the file in
+https://github.com/fonsp/Pluto.jl/blob/5b96b85f1a2500dcefb0a739399f77edf5ae78d6/frontend/common/SetupCellEnvironment.js
+but it also adds the _lodash_ package which is available within Pluto
+*/
+
+import { Library } from "https://cdn.jsdelivr.net/npm/@observablehq/stdlib@3.3.1/+esm"
+import { default as lodash } from "https://cdn.jsdelivr.net/npm/lodash-es@4.17.20/+esm"
+
+const library = new Library()
+
+export const DOM =  library.DOM
+export const Files = library.Files
+export const Generators = library.Generators
+export const Promises = library.Promises
+export const now = library.now
+export const svg = library.svg()
+export const html = library.html()
+export const require = library.require()
+export const _ = lodash
+
+const mod = {
+    DOM, Files, Generators, Promises, now, svg, html, require, _
+}
+
+export default mod

--- a/src/combine_htl/show.jl
+++ b/src/combine_htl/show.jl
@@ -1,0 +1,278 @@
+
+# Helpers #
+# This function just iterates and print the javascript of an iterable containing DualScript elements
+function _iterate_scriptcontents(io::IO, iter, location::SingleDisplayLocation, kind::Symbol = :body)
+	mime = MIME"text/javascript"()
+	# We cycle through the DualScript iterable
+	pluto = plutodefault(location)
+	for pts in iter
+		kwargs = if _eltype(pts) <: Script
+			(;
+				pluto,
+				kind,
+			)
+		else
+			# We only print when iterating the body for non Script elements
+			kind === :body || continue
+			(;pluto)
+		end
+		print_javascript(io, pts; kwargs...)
+	end
+	return nothing
+end
+
+function write_script(io::IO, contents::Vector{<:PrintToScript}, location::InsidePluto; returns = missing, kwargs...)
+	# We cycle through the contents to write the body part
+	_iterate_scriptcontents(io, contents, location, :body)
+	# If there is no valid invalidation, we simply return
+	if hasinvalidation(contents)
+		# We add a separating newline
+		println(io)
+		# Start processing the invalidation
+		println(io, "invalidation.then(() => {")
+		_iterate_scriptcontents(io, contents, location, :invalidation)
+		println(io, "})")
+	end
+	maybe_add_return(io, returns, location)
+	return
+end
+function write_script(io::IO, contents::Vector{<:PrintToScript}, location::OutsidePluto; returns = missing, only_contents = false)
+	# We wrap everything in an async call as we want to use await
+	only_contents || println(io, "(async (currentScript) => {")
+	# If the script should have the added Pluto compat packages we load them
+	if add_pluto_compat(contents) && !only_contents
+		println(io, """
+	// Load the Pluto compat packages from the custom module
+	const {DOM, Files, Generators, Promises, now, svg, html, require, _} = await import('$(LOCAL_MODULE_URL[])')
+""")
+	end
+	# We cycle through the contents to write the body part
+	_iterate_scriptcontents(io, contents, location, :body)
+	# We print the returned element if provided
+	maybe_add_return(io, returns, location)
+	# We close the async function definition and call it with the currentScript
+	only_contents || println(io, "})(document.currentScript)")
+	return
+end
+
+
+## print_javascript ##
+# ScriptContent
+function print_javascript(io::IO, sc::ScriptContent; kwargs...)
+	shouldskip(sc) && return
+	println(io, sc.content) # Add the newline
+end
+# Script
+function print_javascript(io::IO, s::Union{SingleScript, DualScript}; pluto =
+plutodefault(s), kwargs...) 
+	print_javascript(io, CombinedScripts(s); pluto, kwargs...)
+end
+# CombinedScripts
+function print_javascript(io::IO, ms::CombinedScripts; pluto =
+plutodefault(io), only_contents = false)
+	location = displaylocation(pluto)
+	shouldskip(ms, location) && return
+	# We add the listeners handlers if any of the script requires it
+	contents = children(ms) |> copy # We copy to avoid mutating in the next line
+	if haslisteners(ms, location) && !only_contents
+		pushfirst!(contents, _events_listeners_preamble)
+		push!(contents, _events_listeners_postamble)
+	end
+	write_script(io, contents, location; 
+	returns = returned_element(ms, location), only_contents)
+end
+# PrintToScript
+# Default version that just forwards
+function print_javascript(io::IO, pts::PrintToScript; pluto = plutodefault(pts), kwargs...) 
+	l = displaylocation(pluto)
+	# We skip if the loction of pts is explicitly not compatible with l
+	shouldskip(pts, l) && return
+	print_javascript(io, pts.el; pluto, kwargs...)
+	return nothing
+end
+# Here we add methods for PrintToScript containing scripts. These will simply print the relevant ScriptContent
+function print_javascript(io::IO, pts::PrintToScript{<:DisplayLocation, <:Script}; pluto = plutodefault(pts.el), kind = :body)
+	l = displaylocation(pluto)
+	el = pts.el
+	s = el isa DualScript ? inner_node(el, l) : el
+	# We return if the location we want to print is not supported by the script
+	shouldskip(s, l) && return
+	if kind === :invalidation && s isa NormalScript
+		# We error if we are trying to print the invalidation field of a NormalScript
+		error("You can't print invalidation for a NormalScript")
+	end
+	sc = getproperty(s, kind)
+	shouldskip(sc, l) || print_javascript(io, sc)
+	return nothing
+end
+# If the PrintToScript element is a function, we call it passing io and kwargs to it
+function print_javascript(io::IO, pts::PrintToScript{<:DisplayLocation, <:Function}; pluto = is_inside_pluto(io), kwargs...)
+	l = displaylocation(pluto)
+	# We skip if the loction of pts is explicitly not compatible with l
+	shouldskip(pts, l) && return
+	f = pts.el
+	f(io; pluto, kwargs...)
+	return nothing
+end
+# For AbstractDicts, we use HypertextLiteral.print_script 
+function print_javascript(io::IO, d::Union{AbstractDict, NamedTuple, Tuple, AbstractVector}; pluto = is_inside_pluto(io), kwargs...)
+	if pluto
+		pjs = published_to_js(d)
+		show(io, MIME"text/javascript"(), pjs)
+	else
+		HypertextLiteral.print_script(io, d)
+	end
+	return nothing
+end
+# Catchall method reverting to show text/javascript
+print_javascript(io::IO, x; kwargs...) = (@nospecialize; show(io, MIME"text/javascript"(), x))
+
+## Maybe add return ##
+maybe_add_return(::IO, ::Missing, ::SingleDisplayLocation) = nothing
+maybe_add_return(io::IO, name::String, ::InsidePluto) = println(io, "return $name")
+maybe_add_return(io::IO, name::String, ::OutsidePluto) = print(io, "
+	/* code added by PlutoExtras to simulate script return */
+	currentScript.insertAdjacentElement('beforebegin', $name)
+")
+
+# This function will simply write into IO the html code of the script, including the <script> tag
+# This is applicable for CombinedScripts and DualScript
+function print_html(io::IO, s::Script; pluto = plutodefault(s), only_contents = false)
+	location = displaylocation(pluto)
+	shouldskip(s, location) && return
+	# We write the script tag
+	id = script_id(s, location)
+	println(io, "<script id='$id'>")
+	# Print the content
+	print_javascript(io, s; pluto, only_contents)
+	# Print the closing tag
+	println(io, "</script>")
+	return
+end
+print_html(io::IO, s::AbstractString; kwargs...) = write(io, strip_nl(s))
+function print_html(io::IO, n::NonScript{L}; pluto = plutodefault(n)) where L <: SingleDisplayLocation 
+	_pluto = plutodefault(n)
+	# If the location doesn't match the provided kwarg we do nothing
+	xor(pluto, _pluto) && return
+	println(io, n.content)
+	return
+end
+print_html(io::IO, dn::DualNode; pluto = plutodefault(dn)) = print_html(io, inner_node(dn, displaylocation(pluto)); pluto)
+function print_html(io::IO, cn::CombinedNodes; pluto = is_inside_pluto(io))
+	for n in children(cn)
+		print_html(io, n; pluto)
+	end
+end
+function print_html(io::IO, swph::ShowWithPrintHTML; pluto = plutodefault(io, swph)) 
+	l = displaylocation(pluto)
+	# We skip if the loction of pts is explicitly not compatible with l
+	shouldskip(swph, l) && return
+	print_html(io, swph.el; pluto)
+	return nothing
+end
+# If the ShowWithPrintHTML element is a function, we call it passing io and kwargs to it
+function print_html(io::IO, swph::ShowWithPrintHTML{<:DisplayLocation, <:Function}; pluto = plutodefault(io, swph), kwargs...)
+	l = displaylocation(pluto)
+	# We skip if the loction of pts is explicitly not compatible with l
+	shouldskip(swph, l) && return
+	f = swph.el
+	f(io; pluto, kwargs...)
+	return nothing
+end
+# Catchall method reverting to show text/javascript
+print_html(io::IO, x; kwargs...) = (@nospecialize; show(io, MIME"text/html"(), x))
+
+## Formatted Code ##
+
+# We simulate the Pluto iocontext even outside Pluto if want to force printing as in pluto
+_pluto_default_iocontext() = try
+	Main.PlutoRunner.default_iocontext 
+catch
+	function core_published_to_js(io, x)
+		write(io, "/* Here you'd have your published object on Pluto */")
+		return nothing
+	end
+	IOContext(devnull, 
+		:color => false, 
+		:limit => true, 
+		:displaysize => (18, 88), 
+		:is_pluto => true, 
+		# :pluto_supported_integration_features => supported_integration_features,
+		:pluto_published_to_js => (io, x) -> core_published_to_js(io, x),
+	)
+end
+
+function to_string(element, ::M, args...; kwargs...) where M <: MIME
+	f = if M === MIME"text/javascript"
+		print_javascript
+	elseif M === MIME"text/html"
+		print_html
+	else
+		error("Unsupported mime $M provided as input")
+	end
+	to_string(element, f, args...; kwargs...)
+end
+function to_string(element, f::Function, io::IO = IOBuffer(); kwargs...)
+	iocontext = get(kwargs, :iocontext) do 
+		pluto = get(kwargs, :pluto, is_inside_pluto())
+		pluto ? _pluto_default_iocontext() : IOContext(devnull)
+	end
+	f(IOContext(io, iocontext), element; kwargs...)
+	code = String(take!(io))
+	return code
+end
+function formatted_code(s::Union{Script, ScriptContent}, mime::MIME"text/javascript"; kwargs...)
+	codestring = to_string(s, mime; kwargs...)
+	Markdown.MD(Markdown.Code("js", codestring))
+end
+function formatted_code(n::Node, mime::MIME"text/html"; kwargs...)
+	codestring = to_string(n, mime; kwargs...)
+	Markdown.MD(Markdown.Code("html", codestring))
+end
+# Default MIMEs
+default_mime(::ScriptContent) = MIME"text/javascript"()
+default_mime(::Node) = MIME"text/html"()
+formatted_code(s::Union{ScriptContent, Node}; kwargs...) = formatted_code(s, default_mime(s); kwargs...)
+# Versions returning functions
+formatted_code(mime::MIME; kwargs...) = x -> formatted_code(x, mime; kwargs...)
+# This forces just the location using the DisplayLocation type
+formatted_code(l::SingleDisplayLocation; kwargs...) = x -> formatted_code(x; pluto = plutodefault(l), kwargs...)
+formatted_code(; kwargs...) = x -> formatted_code(x; kwargs...) # Default no argument version
+
+formatted_contents(args...; kwargs...) = formatted_code(args...; kwargs..., only_contents = true)
+
+
+HypertextLiteral.content(n::Node) = HypertextLiteral.Render(ShowWithPrintHTML(n, InsideAndOutsidePluto()))
+
+#= Fix for Julia 1.10 
+The `@generated` `print_script` from HypertextLiteral is broken in 1.10
+See [issue 33](https://github.com/JuliaPluto/HypertextLiteral.jl/issues/33)
+We have to also define a method for `print_script` to avoid precompilation errors
+=#
+
+HypertextLiteral.print_script(io::IO, val::ScriptContent) = show(io, MIME"text/javascript"(), val)
+HypertextLiteral.print_script(io::IO, v::Vector{ScriptContent}) = for s in v
+	HypertextLiteral.print_script(io, s)
+end
+
+HypertextLiteral.print_script(::IO, ::Script) = error("Interpolation of `Script` subtypes is not allowed within a script tag.
+Use `make_node` to generate a `<script>` node directly in HTML")
+
+
+# Show - text/javascript #
+function Base.show(io::IO, ::MIME"text/javascript", s::Union{ScriptContent, Script})
+	print_javascript(io, s)
+end
+
+Base.show(::IO, ::MIME"text/javascript", ::T) where T <: Union{ShowWithPrintHTML, NonScript} =
+error("Objects of type `$T` are not supposed to be shown with mime 'text/javascript'")
+
+# Show - text/html #
+Base.show(io::IO, mime::MIME"text/html", sc::ScriptContent) = 
+show(io, mime, formatted_code(sc))
+
+Base.show(io::IO, ::MIME"text/html", s::Node) =
+print_html(io, s; pluto = is_inside_pluto(io))
+
+Base.show(io::IO, ::MIME"text/html", s::ShowWithPrintHTML) = 
+print_html(io, s.el; pluto = plutodefault(io, s))

--- a/src/combine_htl/typedef.jl
+++ b/src/combine_htl/typedef.jl
@@ -1,0 +1,429 @@
+abstract type DisplayLocation end
+abstract type SingleDisplayLocation <: DisplayLocation end
+struct InsidePluto <: SingleDisplayLocation end
+struct OutsidePluto <: SingleDisplayLocation end
+struct InsideAndOutsidePluto <: DisplayLocation end
+
+abstract type AbstractHTML{D<:DisplayLocation} end
+abstract type Node{D} <: AbstractHTML{D} end
+abstract type NonScript{D} <: Node{D} end
+abstract type Script{D} <: Node{D} end
+
+const SingleNode = Node{<:SingleDisplayLocation}
+const SingleScript = Script{<:SingleDisplayLocation}
+
+## ScriptContent ##
+"""
+	$TYPEDEF
+This struct is a simple wrapper for JS script content and is intended to provide
+pretty printing of script contents and custom interpolation inside the
+`<script>` tags of the `@htl` macro.
+
+It is used as building block for creating and combining JS scripts to correctly
+render inside and outside Pluto notebooks. 
+
+# Field
+$TYPEDFIELDS
+
+## Note
+The `addedEventListeners` field is usually automatically computed based on the
+provided `content` value when using one of the 2 main constructors below:
+
+# Main Constructors
+	ScriptContent(s::AbstractString; kwargs...)
+	ScriptContent(r::HypertextLiteral.Result; kwargs...)
+One would usually call the constructor either with a `String` or
+`HypertextLiteral.Result`. In this case, the provided content is parsed and
+checked for calls to the `addScriptEventListeners` function, eventually setting the `addedEventListeners` field accordingly.
+One can force the flag to a custom value either by directly calling the
+(default) inner constructor with 2 positional arguments, or by passing
+`addedEventListeners = value` kwarg to one of the two constructrs above.
+
+For what concerns construction with `HypertextLiteral.Result` as input, the
+provided `Result` needs to contain an opening and closing `<script>` tag. 
+In the example below, the constructor will parse the `Result` and only extracts the content within the tags, so only the `code...` part below.
+All content appearing before or after the <script> tag (including additional
+script tags) will be ignored and a warning will be produced.
+```julia
+wrapper = ScriptContent(@htl(\"\"\"
+something_before
+<script>
+code...
+</script>
+something_after
+\"\"\"))
+```
+When interpolating `wrapper` above inside another `@htl` macro as `@htl
+"<script>\$wrapper</script>"` it would be as equivalent to directly writing
+`code...` inside the script. This is clearly only
+beneficial if multiple `ScriptContent` variables are interpolated inside a
+single <script> block.
+
+On top of the interpolation, an object of type `ScriptContent` will show its
+contents as a formatted javascript code markdown element when shown in Pluto. 
+
+See also: [`PlutoScript`](@ref), [`NormalScript`](@ref), [`DualScript`](@ref)
+
+# Examples
+
+```julia
+let
+	asd = ScriptContent(@htl \"\"\"
+	<script>
+		let out = html`<div></div>`
+		console.log('first script')
+	</script>
+	\"\"\")
+	lol = ScriptContent(@htl \"\"\"
+	<script>
+		let a = Math.random()
+		out.innerText = a
+		console.log('second script')
+		return out
+	</script>
+	\"\"\")
+	@htl \"\"\"
+	<script>
+		\$([
+			asd,
+			lol
+		])
+	</script>
+	\"\"\"
+end
+```
+"""
+struct ScriptContent
+	"Content of the script part"
+	content::String
+	"Flag indicating if the script has custom listeners added via the  `addScriptEventListeners` function."
+	addedEventListeners::Bool
+end
+
+## PlutoScript ##
+"""
+$TYPEDEF
+# Fields
+$TYPEDFIELDS
+
+## Note
+Eventual elements that have to be returned from the script (this is a feature of
+Pluto) should not be directly _returned_ from the script content but should be
+simply assigned to a JS variable whose name is set to the `returned_element`
+field.
+This is necessary to prevent exiting early from a chain of Scripts. For example, the following code which is a valid JS code inside a Pluto cell to create a custom div as output:
+```julia
+@htl \"\"\"
+<script>
+	return html`<div>MY DIV</div>`
+</script>
+\"\"\"
+```
+must be constructed when using `PlutoScript` as:
+```julia
+PlutoScript("let out = html`<div>MY DIV</div>`"; returned_element = "out")
+```
+
+# Additional Constructors
+	PlutoScript(body; kwargs...)
+	PlutoScript(body, invalidation; kwargs...)
+
+For the body and invalidation fields, the constructor also accepts inputs of
+type `String`, `HypertextLiteral.Result` and `IOBuffer`, translating them into
+`ScriptContent` internally.
+
+	PlutoScript(s::PlutoScript; kwargs...)
+This constructor is used to copy the elements from another PlutoScript with the
+option of overwriting the fields provided as `kwargs`
+
+# Description
+
+This struct is used to create and compose scripts together with the `@htl` macro
+from HypertextLiteral. 
+
+It is intended for use inside Pluto notebooks to ease composition of bigger
+scripts via smaller parts.
+
+When an PlutoScript is interpolated inside the `@htl` macro, the following code is generated:
+```html
+<script id=\$id>
+\$body
+
+invalidation.then(() => {
+	\$invalidation
+})
+```
+If the `id = missing` (default), a random string id is associated to the script.
+If `id = nothing`, a script without id is created.
+
+If the `invalidation` field is `missing`, the whole invalidation block is
+skipped.
+
+Multiple `PlutoScript` elements can be combined together using the
+[`combine_script`](@ref) function also exported by this package, allowing to
+generate bigger scripts by composing multiple building blocks.
+
+When shown inside the output of Pluto cells, the PlutoScript object prints its
+containing formatted code as a `Markdown.Code` element.
+
+# Javascript Events Listeners
+
+`PlutoScript` provides some simplified way of adding event listeners in javascript
+that are automatically removed upon cell invalidation. Scripts created using
+`PlutoScript` expose an internal javascript function 
+```js
+addScriptEventListeners(element, listeners)
+```
+which accepts any givent JS `element` to which listeners have to be attached,
+and an object of with the following key-values:
+```js
+{ 
+  eventName1: listenerFunction1, 
+  eventName2: listenerFunction2,
+  ... 
+}
+```
+When generating the script to execute, `PlutoScript` automatically adds all the
+provided listeners to the provided element, and also takes care of removing all
+the listeners upon cell invalidation.
+
+For example, the following julia code:
+```julia
+let
+	script = PlutoScript(@htl(\"\"\"
+<script>
+	addScriptEventListeners(window, { 
+		click: function (event) {
+			console.log('click: ',event)
+		}, 
+		keydown: function (event) {
+			console.log('keydown: ',event)
+		},
+	})
+</script>
+	\"\"\"))
+	@htl"\$script"
+end
+```
+is functionally equivalent of writing the following javascript code within the
+script tag of the cell output
+```js
+function onClick(event) {
+	console.log('click: ',event)
+}
+function onKeyDown(event) {
+	console.log('keydown: ',event)
+}
+window.addEventListener('click', onClick)
+window.addEventListener('keydown', onKeyDown)
+
+invalidation.then(() => {
+	window.removeEventListener('click', onClick)
+	window.removeEventListener('keydown', onKeyDown)
+})
+```
+
+See also: [`ScriptContent`](@ref), [`combine_scripts`](@ref)
+
+# Examples:
+The following code:
+```julia
+let
+a = PlutoScript("console.log('asd')")
+b = PlutoScript(@htl("<script>console.log('boh')</script>"), "console.log('lol')")
+script = combine_scripts([a,b];id="test")
+out = @htl("\$script")
+end
+```
+is equivalent to writing directly
+```julia
+@htl \"\"\"
+<script id='test'>
+	console.log('asd')
+	console.log('boh')
+	
+	invalidation.then(() => {
+		console.log('lol')
+	})
+\"\"\"
+</script>
+```
+"""
+struct PlutoScript <: Script{InsidePluto}
+	"The main body of the script"
+    body::Union{Missing,ScriptContent}
+	"The code to be executed inside the invalidation promise. Defaults to `missing`"
+    invalidation::Union{Missing,ScriptContent}
+	"The id to assign to the script. Defaults to `missing`"
+    id::Union{Missing, String}
+	"The name of the JS element that is returned by the script. Defaults to `missing`"
+	returned_element::Union{Missing, String}
+    function PlutoScript(b,i,id::Union{Missing, Nothing, String}, returned_element; kwargs...) 
+        body = ScriptContent(b; kwargs...)
+        invalidation = ScriptContent(i)
+		@assert invalidation === missing || invalidation.addedEventListeners === false "You can't have added event listeners in the invalidation script"
+        new(body,invalidation, something(id, missing), returned_element)
+    end
+end
+
+## NormalScript
+struct NormalScript <: Script{OutsidePluto}
+	"The main body of the script"
+	body::Union{Missing, ScriptContent}
+	"A flag to indicate if the script should include basic JS libraries available from Pluto. Defaults to `true`"
+	add_pluto_compat::Bool
+	"The id to assign to the script. Defaults to `missing`"
+	id::Union{Missing, String}
+	"The name of the JS element that is returned by the script. Defaults to `missing`"
+	returned_element::Union{Missing, String}
+    function NormalScript(b, add_pluto_compat, id, returned_element; kwargs...) 
+        body = ScriptContent(b; kwargs...)
+        new(body, add_pluto_compat, something(id, missing), returned_element)
+    end
+end
+
+## DualScript ##
+@kwdef struct DualScript <: Script{InsideAndOutsidePluto}
+	inside_pluto::PlutoScript = PlutoScript()
+	outside_pluto::NormalScript = NormalScript()
+	function DualScript(i, o; kwargs...)
+		ip = PlutoScript(i; kwargs...)
+		op = NormalScript(o; kwargs...)
+		new(ip, op)
+	end
+end
+
+
+## PrintToScript
+struct PrintToScript{D<:DisplayLocation, T}
+	el::T
+	PrintToScript(el::T, ::D) where {T, D<:DisplayLocation} = new{D,T}(el)
+end
+
+## CombinedScripts ##
+struct CombinedScripts <: Script{InsideAndOutsidePluto}
+	scripts::Vector{<:PrintToScript}
+	function CombinedScripts(v::Vector{<:PrintToScript}; returned_element = missing) 
+		# We check for only one return expression and it being in the last script
+		return_count = 0
+		return_idx = something(findfirst(x -> x isa Script, v), 0)
+		for (i, s) in enumerate(v)
+			# If no return is present we skip this script
+			hasreturn(s, InsidePluto()) || hasreturn(s, OutsidePluto()) || continue
+			return_count += 1
+			return_idx = i
+		end
+		@assert return_count < 2 "More than one return expression was found while constructing the CombinedScripts. This is not allowed."
+		# If we don't have to set a custom returned_element we just create a new CombinedScripts
+		returned_element === missing && return new(v)
+		final_v = if return_idx === 0
+			# We have to add a DualScript that just returns the element
+			new_v = vcat(v, DualScript(""; returned_element) |> PrintToScript)
+		else
+			new_v = copy(v)
+			dn = new_v[return_idx].el
+			new_v[return_idx] = DualScript(dn; returned_element) |> PrintToScript
+			new_v
+		end
+		new(final_v)
+	end
+end
+struct ShowWithPrintHTML{D<:DisplayLocation, T} <: AbstractHTML{D}
+	el::T
+	ShowWithPrintHTML(el::T, ::D) where {T, D<:DisplayLocation} = new{D,T}(el)
+end
+
+# HTML Nodes #
+# We use a custom IO to parse the HypertextLiteral.Result for removing newlines and checking if empty
+@kwdef struct ParseResultIO <: IO
+	parts::Vector = []
+end
+# Now we define custom print method to extract the Result parts. See
+# https://github.com/JuliaPluto/HypertextLiteral.jl/blob/2bb465047afdfbb227171222049f315545c307fb/src/primitives.jl
+for T in (Bypass, Render, Reprint)
+	Base.print(io::ParseResultIO, x::T) = shouldskip(x) || push!(io.parts, x)
+end
+
+_isnewline(x) = x in ('\n', '\r') # This won't remove tabs and whitespace
+strip_nl(s::AbstractString) = lstrip(_isnewline, rstrip(s))
+_remove_leading(x) = x
+_remove_leading(x::Bypass{<:AbstractString}) = Bypass(lstrip(_isnewline, x.content))
+_remove_trailing(x) = x
+_remove_trailing(x::Bypass{<:AbstractString}) = Bypass(rstrip(isspace, x.content))
+# We define PlutoNode and NormalNode
+for (T, P) in ((:PlutoNode, :InsidePluto), (:NormalNode, :OutsidePluto))
+	block = quote
+		struct $T <: NonScript{$P}
+			content::Result
+			empty::Bool
+		end
+		# Empty Constructor
+		$T() = $T(@htl(""), true)
+		# Constructor from Result
+		function $T(r::Result)
+			io = ParseResultIO()
+			# We don't use show directly to avoid the EscapeProxy here
+			r.content(io)
+			node = if isempty(io.parts)
+				$T(r, true)
+			else
+				# We try to eventually remove trailing and leading redundant spaces
+				xs = io.parts
+				xs[begin] = _remove_leading(xs[begin])
+				xs[end] = _remove_trailing(xs[end])
+				$T(Result(xs...), false)
+			end
+			return node
+		end
+		# Constructor from AbstractString
+		function $T(s::AbstractString)
+			str = strip_nl(s)
+			out = if isempty(str)
+				$T(@htl(""), true)
+			else
+				r = @htl("$(ShowWithPrintHTML(str))")
+				$T(r, false)
+			end 
+		end
+		# No-op constructor
+		$T(t::$T) = t
+		# Generic constructor
+		$T(content) = $T(@htl("$content"))
+	end
+	# Create the function constructing from HypertextLiteral or HTML
+	eval(block)
+end
+
+## DualNode
+struct DualNode <: NonScript{InsideAndOutsidePluto}
+	inside_pluto::PlutoNode
+	outside_pluto::NormalNode
+	DualNode(i::PlutoNode, o::NormalNode) = new(i, o)
+end
+
+## CombinedNodes
+struct CombinedNodes <: NonScript{InsideAndOutsidePluto}
+	nodes::Vector{<:ShowWithPrintHTML}
+	function CombinedNodes(v::Vector) 
+		swph_vec = map(v) do el
+			make_node(el) |> ShowWithPrintHTML
+		end
+		filtered = filter(swph_vec) do el
+			skip_both = shouldskip(el, InsidePluto()) && shouldskip(el, OutsidePluto())
+			!skip_both
+		end
+		new(filtered)
+	end
+end
+
+const Single = Union{SingleNode, SingleScript}
+const Dual = Union{DualScript, DualNode}
+const Combined = Union{CombinedScripts, CombinedNodes}
+
+function Base.getproperty(c::Combined, s::Symbol)
+	if s === :children
+		children(c)
+	else
+		getfield(c,s)
+	end
+end

--- a/src/extended_toc.jl
+++ b/src/extended_toc.jl
@@ -1,6 +1,6 @@
 using HypertextLiteral
 using PlutoUI
-using PlutoDevMacros.PlutoCombineHTL.WithTypes
+using ..PlutoCombineHTL.WithTypes
 
 # Exports #
 export ExtendedTableOfContents, show_output_when_hidden

--- a/src/structbond/StructBondModule.jl
+++ b/src/structbond/StructBondModule.jl
@@ -1,6 +1,6 @@
 module StructBondModule 
     import PlutoUI.Experimental: wrapped
-    using PlutoDevMacros.PlutoCombineHTL.WithTypes
+    using ..PlutoCombineHTL.WithTypes
     import AbstractPlutoDingetjes.Bonds
     import REPL: fielddoc
     using HypertextLiteral

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+HypertextLiteral = "ac1192a8-f4b3-4bfe-ba22-af5b92cd3ab2"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
 Pluto = "c3e4b0f8-55cb-11ea-2926-15256bba5781"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"

--- a/test/combinehtl_module.jl
+++ b/test/combinehtl_module.jl
@@ -1,0 +1,528 @@
+using Test
+using PlutoExtras.PlutoCombineHTL.WithTypes
+using PlutoExtras.PlutoCombineHTL: LOCAL_MODULE_URL
+using PlutoExtras.HypertextLiteral
+using PlutoExtras.PlutoCombineHTL: shouldskip, children, print_html,
+script_id, inner_node, plutodefault, haslisteners, is_inside_pluto, hasreturn,
+add_pluto_compat, hasinvalidation, displaylocation, returned_element, to_string,
+formatted_contents
+import PlutoExtras
+using PlutoExtras.PlutoCombineHTL.AbstractPlutoDingetjes.Display
+
+@testset "make_script" begin
+    ds = make_script("test")
+    @test make_script(ds) === ds
+    @test ds isa DualScript
+    @test inner_node(ds, InsidePluto()).body == inner_node(ds, OutsidePluto()).body
+    @test ds.inside_pluto.body.content === "test"
+    ds = make_script("lol"; id = "asdfasdf")
+    @test script_id(ds, InsidePluto()) === "asdfasdf"
+    @test script_id(ds, OutsidePluto()) === "asdfasdf"
+    ds2 = make_script(
+        make_script(:pluto; body = "lol", id = "asdfasdf"),
+        make_script(:normal; body = "lol", id = "different"),
+    )
+    @test ds.inside_pluto == ds2.inside_pluto
+    @test ds.outside_pluto != ds2.outside_pluto
+
+    @test shouldskip(ScriptContent()) === true
+    @test ScriptContent(nothing) === missing
+    @test ScriptContent(missing) === missing
+    sc = ScriptContent("addScriptEventListeners('lol')")
+    @test sc.addedEventListeners === true
+    sc = ScriptContent("console.log('lol')")
+    @test sc.addedEventListeners === false
+
+
+    @test_logs (:warn, r"No <script> tag was found") make_script(;invalidation = @htl("lol"))
+    @test_logs (:warn, r"More than one <script> tag was found") make_script(@htl("""
+    <script id='lol'>asd</script>
+    <script class='asd'></script>
+    """))
+    @test_logs (:warn, r"The provided input also contained contents outside") make_script(@htl("""
+    <script id='lol'>asd</script>
+    magic
+    """))
+    @test_throws "No closing </script>" make_script(@htl("<script>asd"))
+    ds = make_script(;invalidation = @htl("lol"))
+    @test shouldskip(ds, InsidePluto()) && shouldskip(ds, OutsidePluto()) # The script is empty because with `@htl` we only get the content between the first <script> tag.
+    ds = make_script(;invalidation = "lol")
+    @test shouldskip(ds, InsidePluto()) === false
+    ds = make_script(;invalidation = @htl("<script>lol</script>"))
+    @test !shouldskip(ds, InsidePluto())
+    @test shouldskip(ds, OutsidePluto())
+    @test shouldskip(ds.inside_pluto.body)
+    @test ds.inside_pluto.invalidation.content === "lol"
+
+    ps = PlutoScript("asd", "lol")
+    @test PlutoScript(ps) === ps
+    @test ps.body.content === "asd"
+    @test ps.invalidation.content === "lol"
+    @test shouldskip(ps, InsidePluto()) === false
+    @test shouldskip(ps, OutsidePluto()) === true
+
+    ns = NormalScript("lol")
+    @test NormalScript(ns) === ns
+    @test_throws "You can't construct" NormalScript(ps).body
+
+    let ds = DualScript(ps)
+        @test ds.inside_pluto === ps
+        @test shouldskip(ds, OutsidePluto())
+    end
+    let ds = DualScript(ns)
+        @test ds.outside_pluto === ns
+        @test shouldskip(ds, InsidePluto())
+    end
+
+    cs = make_script([
+        "asd",
+        "lol",
+    ])
+    @test !(hasreturn(cs, InsidePluto()) || hasreturn(cs, OutsidePluto()))
+    @test hasinvalidation(cs) === false
+    @test add_pluto_compat(cs) === true
+    @test cs isa CombinedScripts
+    @test CombinedScripts(cs) === cs
+    @test make_script(cs) === cs
+    @test children(CombinedScripts(ds)) == children(make_script([ds]))
+
+    @test isempty(children(make_script([PlutoScript("asd")]))) === false
+    @test isempty(children(make_script([NormalScript("asd")]))) === false
+
+    make_script(ShowWithPrintHTML(cs)) === cs
+    @test_throws "only valid if `T <: Script`" make_script(ShowWithPrintHTML("asd"))
+
+    # Now we test that constructing a CombinedScripts with a return in not the last script or more returns errors.
+    ds1 = make_script(PlutoScript(;returned_element = "asd"))
+    ds2 = make_script("asd")
+
+    @test_throws "More than one return" make_script([
+        ds1,
+        ds2,
+        ds1,
+    ])
+    ds3 = make_script(PlutoScript(;returned_element = "asd"), NormalScript(;returned_element = "boh"))
+    cs = make_script([
+        ds2,
+        ds3
+        ]; returned_element = "lol"
+    )
+    @test returned_element(cs, InsidePluto()) === "lol"
+    @test returned_element(cs, OutsidePluto()) === "lol"
+    @test returned_element(ds3, InsidePluto()) === "asd"
+    @test returned_element(ds3, OutsidePluto()) === "boh"
+
+    cs = make_script([
+        PrintToScript(3)
+    ]; returned_element = "asd")
+    @test last(children(cs)).el isa DualScript
+
+    @test make_script(:outside, ds2) === ds2.outside_pluto
+    @test make_script(:Inside, ds2) === ds2.inside_pluto
+
+    pts = PrintToScript(3)
+    @test make_script(pts) === pts
+    @test make_node(pts) isa CombinedScripts
+
+    @test PrintToScript(pts) === pts
+    @test_throws "You can't wrap" PrintToScript(PlutoNode("asd"))
+
+    pts = PrintToScript("asd")
+    @test pts.el isa DualScript
+end
+
+@testset "make_node" begin
+    dn = make_node()
+    @test dn isa DualNode
+    @test shouldskip(dn, InsidePluto()) && shouldskip(dn, OutsidePluto())
+
+    s = make_script("asd")
+    dn = make_node("asd")
+    @test make_node(s) === s
+    @test dn != s
+    @test make_node(dn) === dn
+    cn = make_node([
+        "asd",
+        "",
+        "lol"
+    ])
+    @test cn isa CombinedNodes
+    @test CombinedNodes(cn) === cn
+    @test length(children(cn)) === 2 # We skipped the second empty element
+    @test make_node(cn) === cn
+
+    cn = CombinedNodes(dn)
+    dn_test = cn.children[1].el
+    @test dn_test == dn
+
+    @test PlutoNode(dn.inside_pluto) === dn.inside_pluto
+    @test PlutoNode(@htl("")).empty === true
+
+    nn = NormalNode("lol")
+    dn = DualNode(nn)
+    @test inner_node(dn, OutsidePluto()) === nn
+    @test shouldskip(dn, InsidePluto())
+
+    pn = PlutoNode("asd")
+    dn = DualNode(pn)
+    @test inner_node(dn, InsidePluto()) === pn
+    @test shouldskip(dn, OutsidePluto())
+    @test shouldskip(dn, InsidePluto()) === false
+
+
+    dn = DualNode("asd", "lol")
+    @test inner_node(dn, InsidePluto()) == pn
+    @test inner_node(dn, OutsidePluto()) == nn
+    @test DualNode(dn) === dn
+
+    function compare_content(n1, n2; pluto = missing)
+        io1 = IOBuffer()
+        io2 = IOBuffer()
+        print_html(io1, n1; pluto = pluto === missing ? plutodefault(n1) : pluto)
+        print_html(io2, n2; pluto = pluto === missing ? plutodefault(n2) : pluto)
+        String(take!(io1)) == String(take!(io2))
+    end
+    
+    @test compare_content(make_node(HTML("asd")), make_node("asd"))
+    @test compare_content(NormalNode("asd"), NormalNode(ShowWithPrintHTML("asd")))
+    @test compare_content(PlutoNode("asd"), NormalNode("asd"))
+    @test compare_content(PlutoNode("asd"), NormalNode("asd"); pluto = true) === false
+    @test compare_content(PlutoNode("asd"), NormalNode("asd"); pluto = false) === false
+
+    function test_stripping(inp, expected)
+        dn = make_node(inp)
+        pn = inner_node(dn, InsidePluto())
+        io = IOBuffer()
+        print_html(io, pn)
+        s = String(take!(io))
+        s === expected
+    end
+
+    @test test_stripping("\n\n  a\n\n","  a\n") # Only leading newlines (\r or \n) are removed
+    @test test_stripping("\n\na  \n\n","a\n") # Only leading newlines (\r or \n) are removed
+    @test test_stripping(@htl("lol"), "lol\n")
+    @test test_stripping(@htl("
+    lol
+    
+    "), "    lol\n") # lol is right offset by 4 spaces
+
+    
+    @test isempty(children(make_node([PlutoNode("asd")]))) === false
+    @test isempty(children(make_node([NormalNode("asd")]))) === false
+
+    @test make_node(:pluto, "asd") === PlutoNode("asd")
+    @test make_node(:outside; content = "lol") === NormalNode("lol")
+    @test make_node(:both, "asd", "lol") === DualNode("asd", "lol")
+    @test make_node(:both, "asd", "lol") === make_node("asd", "lol")
+end
+
+@testset "Other Helpers" begin
+    @test shouldskip(3) === false
+    s = make_html(PlutoScript())
+    @test s isa ShowWithPrintHTML
+    @test make_html(s) === s
+    for T in (HypertextLiteral.Render, HypertextLiteral.Bypass)
+        @test shouldskip(T("lol")) === false
+        @test shouldskip(T("")) === true
+    end
+
+    # We should not skip a script it is empty content but with an id
+    @test shouldskip(PlutoScript(""), InsidePluto()) == true
+    @test shouldskip(PlutoScript(""; id = "lol"), InsidePluto()) == false
+    @test shouldskip(NormalScript(""; id = "lol"), OutsidePluto()) == false
+    ds = DualScript(""; id = "lol")
+    @test shouldskip(ds, InsidePluto()) == shouldskip(ds, OutsidePluto()) == false
+
+    for l in (InsidePluto(), OutsidePluto())
+        @test haslisteners(make_script("asd"), l) === false
+    end
+    s = "addScriptEventListeners('lol')"
+    @test haslisteners(make_script(s, "asd"), InsidePluto()) === true
+    @test haslisteners(make_script(s, "asd"), OutsidePluto()) === false
+    @test haslisteners(missing) === false
+
+    @test_throws "can not identify a display location" displaylocation(:not_exist)
+
+    @test hasreturn(make_script("asd","lol"), InsidePluto()) === false
+    @test hasreturn(make_script("asd","lol"), OutsidePluto()) === false
+    ds = make_script(PlutoScript(; returned_element = "asd"),"lol")
+    @test shouldskip(ds.inside_pluto) === false
+    @test hasreturn(ds, InsidePluto()) === true
+    @test hasreturn(ds, OutsidePluto()) === false
+    @test hasreturn(make_script(NormalScript(;returned_element = "lol")), OutsidePluto()) === true
+    @test hasreturn(make_script(NormalScript(;returned_element = "lol")), InsidePluto()) === false
+
+    cs = make_script([
+        "asd",
+        "lol",
+    ])
+    cn = make_node([
+        "asd",
+        "lol",
+    ])
+    # Test getproperty
+    @test cs.children === children(cs)
+    @test cn.children === children(cn)
+
+    # We test the abstract type constructors
+    @test Script(InsideAndOutsidePluto()) === DualScript
+    @test Script(InsidePluto()) === PlutoScript
+    @test Script(OutsidePluto()) === NormalScript
+
+    @test Node(InsideAndOutsidePluto()) === DualNode
+    @test Node(InsidePluto()) === PlutoNode
+    @test Node(OutsidePluto()) === NormalNode
+
+    ps = PlutoScript("asd")
+    ns = NormalScript("asd")
+    ds = make_script(ps,ns)
+    @test DualScript("asd") == ds
+    @test_throws "can't construct" PlutoScript(ns)
+    @test_throws "can't construct" NormalScript(ps)
+
+    @test PlutoScript(ds) === ps
+    @test NormalScript(ds) === ns
+
+    for D in (InsidePluto, OutsidePluto, InsideAndOutsidePluto)
+        @test plutodefault(D) === plutodefault(D())
+        @test displaylocation(D()) === D()
+    end
+    io = IOBuffer()
+    swp1 = ShowWithPrintHTML(make_node("asd"); display_type = :pluto)
+    swp2 = ShowWithPrintHTML(make_node("asd"); display_type = :both) # :both is the default
+    @test plutodefault(io, swp1) === plutodefault(swp1)
+    @test plutodefault(io, swp2) === is_inside_pluto(io) !== plutodefault(swp1)
+
+    @test displaylocation(PrintToScript(3)) === InsideAndOutsidePluto()
+    @test displaylocation(PrintToScript(PlutoScript("asd"))) === InsidePluto()
+
+    swph = ShowWithPrintHTML(3)
+    @test PlutoCombineHTL._eltype(swph) === Int
+    @test shouldskip(swph, InsidePluto()) === false
+
+    swph = ShowWithPrintHTML(3; display_type = :outside)
+    @test shouldskip(swph, InsidePluto()) === true
+
+    @test add_pluto_compat(3) === false
+    @test hasinvalidation(3) === false
+
+    @test haslisteners(PrintToScript(3)) === false
+    @test hasreturn(PrintToScript(3)) === false
+
+    @test script_id(PlutoScript("asd"), OutsidePluto()) === missing
+    pts = PrintToScript(3)
+    @test script_id(pts) === missing
+
+    @test_throws "You can't wrap object" ShowWithPrintHTML(PrintToScript(3))
+end
+
+@testset "Show methods" begin
+    ps = PlutoScript("asd", "lol")
+    s = to_string(ps, MIME"text/javascript"())
+    hs = to_string(ps, MIME"text/html"())
+    @test contains(s, r"JS Listeners .* PlutoExtras") === false # No listeners helpers should be added
+    @test contains(s, "invalidation.then(() => {\nlol") === true # Test that the invaliation script is printed
+    @test contains(hs, r"<script id='\w+'") === true
+
+    struct ASD end
+    function PlutoCombineHTL.print_javascript(io::IO, ::ASD; pluto)
+        if pluto
+            println(io, "ASD_PLUTO")
+        else
+            println(io, "ASD_NONPLUTO")
+        end
+    end
+
+    cs = make_script([ASD() |> PrintToScript])
+    s_in = to_string(cs, MIME"text/javascript"(); pluto = true)
+    s_out = to_string(cs, MIME"text/javascript"(); pluto = false)
+    @test contains(s_in, "ASD_PLUTO")
+    @test contains(s_out, "ASD_NONPLUTO")
+
+    struct LOL end
+    function PlutoCombineHTL.print_javascript(io::IO, ::LOL; pluto)
+        if pluto
+            show(io, MIME"text/javascript"(), published_to_js(3))
+            println(io)
+        else
+            println(io, "LOL_NONPLUTO")
+        end
+    end
+
+    # We test that the custom struct wrapped with PrintToScript is not also being printed as invalidaion
+    cs = CombinedScripts([
+        PrintToScript(LOL())
+        PlutoScript("asd","lol")    
+    ]) 
+    s_in = to_string(cs, print_javascript; pluto = true)
+    @test length(findall("published object on Pluto", s_in)) == 1
+
+    ds = DualScript("addScriptEventListeners('lol')", "magic"; id = "custom_id")
+    s_in = to_string(ds, MIME"text/javascript"(); pluto = true)
+    s_out = to_string(ds, MIME"text/javascript"(); pluto = false)
+    @test contains(s_in, r"JS Listeners .* PlutoExtras") === true
+    @test contains(s_out, r"JS Listeners .* PlutoExtras") === false # The listeners where only added in Pluto
+    hs_in = to_string(ds, MIME"text/html"(); pluto = true)
+    hs_out = to_string(ds, MIME"text/html"(); pluto = false)
+    @test contains(hs_in, "<script id='custom_id'>") === true
+    @test contains(hs_out, "<script id='custom_id'>") === true
+
+    # Test error with print_script
+    @test_throws "Interpolation of `Script` subtypes is not allowed" HypertextLiteral.print_script(IOBuffer(), ds)
+    # Test error with show javascript ShowWithPrintHTML
+    @test_throws "not supposed to be shown with mime 'text/javascript'" show(IOBuffer(), MIME"text/javascript"(), make_html("asd"))
+    # Test error when trying to print invalidation of a NormalScript
+    pts = PrintToScript(NormalScript("lol"))
+    @test_throws "can't print invalidation" print_javascript(IOBuffer(), pts; pluto = false, kind = :invalidation)
+    # Test that print_javascript goes to Base.show with mime text/javascript by default
+    @test_throws r"matching show\(.*::Missing" print_javascript(IOBuffer(), missing)
+    # Test that print_javascript goes to Base.show with mime text/javascript by default
+    @test_throws r"matching show\(.*::Missing" print_html(IOBuffer(), missing)
+    # Test that to_string only supports text/html and text/javascript
+    @test_throws "Unsupported mime" to_string(1, MIME"text/plain"())
+
+    n = NormalNode("asd")
+    # Test that interpolation of nodes in @htl works
+    r = @htl("$n")
+    s = to_string(r, MIME"text/html"(); pluto = false)
+    @test contains(s, "asd")
+
+    cn = make_node([n])
+    s = to_string(cn, MIME"text/html"(); pluto = false)
+    @test contains(s, "asd")
+
+    # Test that interpolation of ScriptContent inside @htl <script> tags work 
+    sc = ScriptContent("asd")
+    r = @htl("<script>$([sc])</script>")
+    s = to_string(r, MIME"text/html"())
+    @test contains(s, "<script>asd")
+
+    # Show outside Pluto
+    # PlutoScript should be empty when shown out of Pluto
+    n = PlutoScript("asd")
+    s_in = to_string(n, MIME"text/html"(); pluto = true)
+    s_out = to_string(n, MIME"text/html"(); pluto = false)
+    @test contains(s_in, "script id='") === true
+    @test isempty(s_out)
+    @test contains(string(formatted_code(n)), "```html\n<script id='")
+
+    # ScriptContent should just show as repr outside of Pluto
+    sc = ScriptContent("asd")
+    s_in = formatted_code(sc; pluto = true) |> string
+    s_out = formatted_code(sc; pluto = false) |> string
+    @test contains(s_in, "```js\nasd\n") # This is language-js
+    @test s_out === s_in # The pluto kwarg is ignored for script content when shown to text/html
+
+    # DualScript
+    n = DualScript("asd", "lol"; id = "asd")
+    s_in = to_string(n, MIME"text/html"(); pluto = true)
+    s_out = to_string(n, MIME"text/html"(); pluto = false)
+    @test contains(s_in, "script id='asd'") === true
+    @test contains(s_out, "script id='asd'") === true
+    @test contains(string(formatted_code(n; pluto=true)), "```html\n<script id='asd'")
+    @test add_pluto_compat(n) === true
+    @test contains(s_out, LOCAL_MODULE_URL[])
+    @test contains(s_out, "async (currentScript) =>") # Opening async outside Pluto
+    @test contains(s_out, "})(document.currentScript)") # Closing and calling async outside Pluto
+    # Test when Pluto compat is false
+    n = DualScript(n; add_pluto_compat = false)
+    @test add_pluto_compat(n) === false
+    s_out = to_string(n, MIME"text/html"(); pluto = false)
+    @test contains(s_out, LOCAL_MODULE_URL[]) === false
+    # Test the return
+    n = DualScript(PlutoScript(;returned_element = "asd"), NormalScript(;returned_element = "lol"))
+    s_in = to_string(n, MIME"text/html"(); pluto = true)
+    s_out = to_string(n, MIME"text/html"(); pluto = false)
+    @test contains(s_in, "return asd")
+    @test contains(s_out, "currentScript.insertAdjacentElement('beforebegin', lol)")
+
+    # NormalNode should be empty when shown out of Pluto
+    n = NormalNode("asd")
+    s_in = to_string(n, MIME"text/html"(); pluto = true)
+    s_out = to_string(n, MIME"text/html"(); pluto = false)
+    @test isempty(s_in) === true
+    @test s_out === "asd\n"
+
+    ds = DualScript("addScriptEventListeners(asd)", "lol"; id = "asd") # Forcing same id is necessary for equality
+    for mime in (MIME"text/javascript"(), MIME"text/html"())
+        @test formatted_code(mime)(ds) == formatted_code(ds, mime)
+    end
+    @test formatted_contents()(ds) == formatted_code(ds; only_contents = true)
+    mime = MIME"text/html"()
+    for l in (InsidePluto(), OutsidePluto())
+        @test formatted_contents(l)(ds) != formatted_code(l; only_contents = false)
+    end
+
+    @test formatted_code(ds) == formatted_code(ds, MIME"text/html"())
+    sc = ScriptContent("asd")
+    @test formatted_code(sc) == formatted_code(sc, MIME"text/javascript"())
+    s = let
+        io = IOBuffer()
+        show(io, MIME"text/html"(), sc)
+        String(take!(io))
+    end
+    @test contains(s, "<div class=\"markdown\"")
+    s = let
+        io = IOBuffer()
+        n = NormalNode("lol")
+        show(io, MIME"text/html"(), n)
+        String(take!(io))
+    end
+    @test contains(s, "lol")
+
+    # We test PrintToScript and ShowWithPrintHTML with io accepting functions
+    pts = PrintToScript((io; pluto, kwargs...) -> let # We wrap everything in an async call as we want to use await
+        write(io, pluto ? "PLUTO" : "NONPLUTO")
+    end)
+    s_in = to_string(pts, print_javascript; pluto = true)
+    s_out = to_string(pts, print_javascript; pluto = false)
+    @test s_in === "PLUTO"
+    @test s_out === "NONPLUTO"
+
+    swph = ShowWithPrintHTML((io; pluto, kwargs...) -> let # We wrap everything in an async call as we want to use await
+        write(io, pluto ? "PLUTO" : "NONPLUTO")
+    end)
+    s_in = to_string(swph, print_html; pluto = true)
+    s_out = to_string(swph, print_html; pluto = false)
+    @test s_in === "PLUTO"
+    @test s_out === "NONPLUTO"
+
+    # We test print_javascript for dicts
+    d = Dict("asd" => "lol")
+    s_in = to_string(d, print_javascript; pluto = true) 
+    s_out = to_string(d, print_javascript; pluto = false)
+    @test contains(s_in, "published object on Pluto")
+    @test s_out === """{"asd": "lol"}""" 
+
+    # We test print_javascript for vectors
+    v = ["asd", "lol"]
+    s_in = to_string(v, print_javascript; pluto = true) 
+    s_out = to_string(v, print_javascript; pluto = false)
+    @test contains(s_in, "published object on Pluto")
+    @test s_out === """["asd", "lol"]""" 
+end
+
+# import Pluto: update_save_run!, update_run!, WorkspaceManager, ClientSession,
+# ServerSession, Notebook, Cell, project_relative_path, SessionActions,
+# load_notebook, Configuration
+
+# function noerror(cell; verbose=true)
+#     if cell.errored && verbose
+#         @show cell.output.body
+#     end
+#     !cell.errored
+# end
+
+# options = Configuration.from_flat_kwargs(; disable_writing_notebook_files=true, workspace_use_distributed_stdlib = true)
+# srcdir = normpath(@__DIR__, "./notebooks")
+# eval_in_nb(sn, expr) = WorkspaceManager.eval_fetch_in_workspace(sn, expr)
+
+# @testset "Script test notebook" begin
+#     ss = ServerSession(; options)
+#     path = joinpath(srcdir, "Script.jl")
+#     nb = SessionActions.open(ss, path; run_async=false)
+#     for cell in nb.cells
+#         @test noerror(cell)
+#     end
+#     SessionActions.shutdown(ss, nb)
+# end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,7 @@ using PlutoExtras
 
 Aqua.test_all(PlutoExtras)
 
+@safetestset "PlutoCombineHTL Module" begin include("combinehtl_module.jl") end
 @safetestset "Basic Widgets" begin include("basics.jl") end
 @safetestset "LaTeX Equations" begin include("latex.jl") end
 @safetestset "Extended Toc" begin include("toc.jl") end


### PR DESCRIPTION
This PR removes the dependency on PlutoDevMacros as it was only used for its PlutoHTLCombine submodule (which was removed in https://github.com/disberd/PlutoDevMacros.jl/pull/52).

To remove this dependency we just copied the old module from PlutoDevMacros inside PlutoExtras.

In the future we should probably refactor the code to avoid using it and write directly most of the js part of the library as a JS library.