### PR TITLE
Add collapsed customization in BondTable

### DIFF
--- a/src/PlutoExtras.jl
+++ b/src/PlutoExtras.jl
@@ -19,6 +19,8 @@ end
 export Editable, StringOnEnter # from basic_widgets.jl
 export ToggleReactiveBond # From within StructBondModule
 
+include("helpers.jl")
+
 include("combine_htl/PlutoCombineHTL.jl")
 
 include("basic_widgets.jl")

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -1,0 +1,12 @@
+# This function is an internal helper that returns just the letters (without numbers and dashes) of the currently running cell id. Returns a random string of 10 letters in case the currently running cell id can not be parsed. Mostly used to produce consistent ids for javascript scripts in Pluto
+function cell_id_letters(limit = 10)
+    fallback = String(rand('a':'z', 10))
+    isdefined(Main, :PlutoRunner) || return fallback
+    isdefined(Main.PlutoRunner, :currently_running_cell_id) || return fallback
+    ref = Main.PlutoRunner.currently_running_cell_id
+    (ref isa Ref && isassigned(ref)) || return fallback
+    uuid = ref[]
+    # Return up to `limit` characters
+    str = replace(string(uuid), r"[\d-]" => "")
+    return first(str, limit)
+end

--- a/src/structbond/StructBondModule.jl
+++ b/src/structbond/StructBondModule.jl
@@ -5,6 +5,7 @@ module StructBondModule
     import REPL: fielddoc
     using HypertextLiteral
     using PlutoUI: combine
+    using ..PlutoExtras: cell_id_letters
 
     export BondTable, StructBond, @NTBond, @BondsList, Popout, @popoutasfield,
     @typeasfield, popoutwrap, @fieldbond, @fielddescription, @fielddata

--- a/src/structbond/main_definitions.jl
+++ b/src/structbond/main_definitions.jl
@@ -389,12 +389,20 @@ _getbond(x::Popout) = _getbond(x.element)
 
 # BondTable #
 """
-	BondTable(bondarray; description)
+	BondTable(bondarray; description, collapsed)
 Take as input an array of bonds and creates a floating table that show all the
 bonds in the input array. 
 
 If `description` is not provided, it defaults to the text *BondTable*.
 Description can be either a string or a HTML output.
+
+The optional `collapsed` kwarg can be used to specify whether the BondTable
+should stay collapsed or not when shown. If not provided, the BondTable will
+*not* be collapsed.
+
+The *collapsed* status of the BondTable is persistent across reactive runs of
+the cell showing the BondTable.
+
 
 See also: [`StructBond`](@ref), [`Popout`](@ref), [`popoutwrap`](@ref),
 [`@fieldbond`](@ref), [`@fielddescription`](@ref), [`@fieldhtml`](@ref),


### PR DESCRIPTION
This PR adds a way to specify whether the BondTable shall be collapsed by default when shown.
This will also maintain persistent collapsed status between reactive runs of cell showing the BondTable

Closes #36 