### PR TITLE
Add Dict-like widget for StructBond elements

### DIFF
--- a/src/structbond/StructBondModule.jl
+++ b/src/structbond/StructBondModule.jl
@@ -4,11 +4,12 @@ module StructBondModule
     import AbstractPlutoDingetjes.Bonds
     import REPL: fielddoc
     using HypertextLiteral
-    using PlutoUI: combine
+    using PlutoUI: combine, Select, Experimental.TransformedValueNotebook.TransformedWidget
     using ..PlutoExtras: cell_id_letters
 
     export BondTable, StructBond, @NTBond, @BondsList, Popout, @popoutasfield,
     @typeasfield, popoutwrap, @fieldbond, @fielddescription, @fielddata
+    export StructBondSelect
     export ToggleReactiveBond
 
     const CSS_Sheets = map(readdir(joinpath(@__DIR__, "css"))) do file
@@ -20,5 +21,6 @@ module StructBondModule
     include("toggle_reactive.jl")
     include("basics.jl")
     include("main_definitions.jl")
+    include("structbond_select.jl")
     include("macro.jl")
 end

--- a/src/structbond/basics.jl
+++ b/src/structbond/basics.jl
@@ -129,6 +129,12 @@ function typehtml(T::Type)
 		])
 		"""
 	end
+    togglereactive_container(inner_bond; description = typedescription(T), title = "This generates a struct of type $(nameof(T))")
+end
+
+## ToggleReactiveContainer ##
+# This is a helperfunction to create a togglereactive container around a bond with collapsible content
+function togglereactive_container(inner_bond; description, title)
 	ToggleReactiveBond(wrapped() do Child
 		@htl("""
 			$(Child(inner_bond))
@@ -137,7 +143,7 @@ function typehtml(T::Type)
 		const trc = currentScript.closest('togglereactive-container')
 		const header = trc.firstElementChild
 		const desc = header.querySelector('.description')
-		desc.setAttribute('title', "This generates a struct of type `$(nameof(T))`")
+		desc.setAttribute('title', $title)
 
 		// add the collapse button
 		const collapse_btn = html`<span class='collapse'>`
@@ -202,7 +208,7 @@ function typehtml(T::Type)
 			}
 		</style>
 		""")
-	end; description = typedescription(T))
+	end; description = description)
 end
 
 ### Constructor ###

--- a/src/structbond/css/structbondselect.css
+++ b/src/structbond/css/structbondselect.css
@@ -1,0 +1,76 @@
+structbond-select togglereactive-container:first-of-type.no-popout:before {
+  display: none;
+}
+
+structbond-select > struct-bond.hidden {
+  display: none;
+}
+
+structbond-select,
+structbond-select > struct-bond,
+structbond-select togglereactive-container {
+  display: contents;
+}
+
+structbond-select > .selector {
+  display: contents;
+}
+
+structbond-select > .selector .description {
+  color: var(--pluto-output-color, #404040);
+  font-size: 14px;
+}
+
+structbond-select >struct-bond>togglereactive-container>togglereactive-header {
+  display: none;
+}
+
+structbond-select > .selector select {
+    padding: 6px 12px;
+    border: 2px solid #e7e7e7;
+    border-radius: 6px;
+    background-color: var(--overlay-button-bg);
+    color: var(--pluto-output-color, #404040);
+    font-size: 14px;
+    font-family: inherit;
+    cursor: pointer;
+    outline: none;
+    transition: border-color 0.2s;
+    
+    /* Custom arrow styling */
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    /* Light mode arrow - #404040 */
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23404040' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 8px center;
+    background-size: 16px;
+    padding-right: 32px;
+    min-width: 120px;
+}
+
+structbond-select > .selector select:hover {
+    border-color: #d0d0d0;
+}
+
+structbond-select > .selector select:focus {
+    border-color: #c0c0c0;
+}
+
+@media (prefers-color-scheme: dark) {
+    structbond-select > .selector select {
+        border-color: #7d7d7d;
+        color: var(--pluto-output-color, #c4c4c4);
+        /* Dark mode arrow - #c4c4c4 */
+        background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23c4c4c4' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+    }
+    
+    structbond-select > .selector select:hover {
+        border-color: #8a8a8a;
+    }
+    
+    structbond-select > .selector select:focus {
+        border-color: #7d7d7d;
+    }
+}

--- a/src/structbond/macro.jl
+++ b/src/structbond/macro.jl
@@ -292,7 +292,6 @@ macro NTBond(desc, block)
 		Meta.isexpr(arg, :(=)) || error("Only expression of type `fieldname = fieldbond` or `fieldname = (fielddescription, fieldbond)` can be provided inside the block fed to @NTBond")
 		push!(fields, arg.args[1])
 	end
-	Mod = @__MODULE__
 	T = NamedTuple{Tuple(fields)}
 	out = _add_generic_field(T, block, [:fielddescription, :fieldbond])
 	# We add the generation of the StructBond

--- a/src/structbond/structbond_select.jl
+++ b/src/structbond/structbond_select.jl
@@ -1,0 +1,134 @@
+# Valid elements for StructBondSelect
+
+valid_structbondselect_el(el::StructBond) = true
+valid_structbondselect_el(el::TransformedWidget{<:StructBond}) = true
+
+extract_description(el::StructBond) = el.description
+extract_description(el::TransformedWidget{<:StructBond}) = el.x.description
+
+"""
+    StructBondSelect(els::Vector{<:StructBond})
+
+A bond that displays a dropdown menu with the descriptions of the given StructBonds.
+When the user selects one of the options, the corresponding StructBond is displayed.
+
+See also: [`StructBond`](@ref)
+"""
+struct StructBondSelect
+	els::Vector
+    selectors::Vector{String}
+    selector_text::String
+    default_idx::Int
+    description::String
+end
+
+
+function StructBondSelect(els::Vector, selectors::Vector{String}; default_idx = 1, description = "StructBondSelect", selector_text = "Selector")
+    all(valid_structbondselect_el, els) || throw(ArgumentError("All elements in els must be either a StructBond or a TransformedWidget{StructBond} (obtained from a StructBond using `PlutoUI.Experimental.transformed_value`)"))
+    StructBondSelect(els, selectors, selector_text, default_idx, description)
+end
+
+function StructBondSelect(els::Vector; kwargs...)
+    all(valid_structbondselect_el, els) || throw(ArgumentError("All elements in els must be either a StructBond or a TransformedWidget{StructBond} (obtained from a StructBond using `PlutoUI.Experimental.transformed_value`)"))
+    StructBondSelect(els, map(extract_description, els); kwargs...)
+end
+
+function StructBondSelect(ps::Vector{<:Pair{<:AbstractString, <:Any}}; kwargs...)
+    StructBondSelect(last.(ps), first.(ps); kwargs...)
+end
+
+function Base.show(io::IO, mime::MIME"text/html", sb::StructBondSelect)
+    inner_bond = @htl("""
+    <structbond-select>
+        <span class="selector">
+            <span class="description">$(sb.selector_text)</span>
+            $(Select(sb.selectors))
+        </span>
+        $([el for el in sb.els])
+        <script>
+            const parent = currentScript.parentElement
+            const set_input_value = setBoundElementValueLikePluto
+            const get_input_value = getBoundElementValueLikePluto
+            
+            // This is the element of the select dropdown
+            const select = parent.querySelector("select")
+
+            // This will hold the currently selected structbond element
+            let selected
+
+            const update = () => {
+                parent.dispatchEvent(new CustomEvent("input"))
+            }
+
+            const change_selection = (value, trigger_event = true) => {
+                set_input_value(select, value)
+                const bonds = parent.querySelectorAll("struct-bond")
+                for (let i = 0; i < bonds.length; i++) {
+                    if (i != value - 1) {
+                        bonds[i].classList.toggle("hidden", true)
+                    } else {
+                        bonds[i].classList.toggle("hidden", false)
+                        selected = bonds[i]
+                    }
+                }
+                if (trigger_event) {
+                    update()
+                }
+            }
+
+            change_selection(get_input_value(select), false)
+
+            Object.defineProperty(parent, "value", {
+                get: () => {
+                    const index = get_input_value(select)
+                    const value = get_input_value(selected)
+                    return [index, value]
+                },
+                set: (newval) => {
+                    change_selection(newval[0], false)
+                    set_input_value(selected, newval[1])
+                },
+            })
+
+            // We add a listener that extract the forward the input event in case the target of the event is the selected bond
+            for (let bond of parent.querySelectorAll("struct-bond")) {
+                bond.addEventListener("input", (e) => {
+                    e.stopPropagation()
+                    if (bond == selected) {
+                        update()
+                    }
+                })
+            }
+
+            parent.addEventListener("input", (e) => {
+                console.log("input event ", e)
+            })
+
+
+            select.addEventListener("input", (e) => {
+                const value = get_input_value(select)
+                e.stopPropagation()
+                change_selection(value)
+            })
+        </script>
+        <style>
+            $(CSS_Sheets.structbondselect)
+        </style>
+    </structbond-select>
+    """)
+    show(io, mime, togglereactive_container(inner_bond; description = sb.description, title = "Use the selector to choose which StructBond to display and use."))
+end
+
+Bonds.initial_value(sbc::StructBondSelect) = Bonds.initial_value(sbc.els[sbc.default_idx])
+
+function Bonds.validate_value(sbc::StructBondSelect, from_js)
+	index, value = from_js |> first
+	idx = parse(Int, index)
+	idx <= length(sbc.els) && Bonds.validate_value(sbc.els[idx], value)
+end
+
+function Bonds.transform_value(sbc::StructBondSelect, from_js)
+	index, value = from_js |> first
+	idx = parse(Int, index)
+	Bonds.transform_value(sbc.els[idx], value)
+end


### PR DESCRIPTION
This PR adds a first draft implementation of what discussed in the comments of #40

It allows to defined a widget by specifying a list of `StructBond` elements and provides a selector to choose which one to use for returning the bound variable.

This can be useful when a bond might require different possible number of fields/variables depending on a selector.

Here a small video example of how this is working:

https://github.com/user-attachments/assets/61aafc8b-e8bb-49b9-b733-c0e3e40e11d0

